### PR TITLE
feat(pptx): storyline PowerPoint export infrastructure

### DIFF
--- a/22-executive/10_pptx_figure_registry
+++ b/22-executive/10_pptx_figure_registry
@@ -1,0 +1,67 @@
+# ===========================================================================
+# PPTX FIGURE REGISTRY: Setup for PPTX export
+# ===========================================================================
+# Run AFTER all analysis cells have been executed.
+#
+# This cell does NOT try to capture figures from memory (they're already
+# gone after plt.show()). Instead it sets up the infrastructure for the
+# export cell (11_pptx_export), which re-executes each chart cell with
+# plt.show() intercepted to save PNGs.
+#
+# The key insight: all DataFrames, palettes, and helper functions are
+# still in the notebook's globals(). The export engine re-runs each
+# cell file using exec() in that namespace, but patches plt.show()
+# to save to PNG instead of displaying.
+
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Set up paths
+# ---------------------------------------------------------------------------
+# Base path: root of the cell files (the txn-visual-test directory)
+# Adjust this if your notebook is in a different location relative to cells.
+PPTX_BASE_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath('.')), '')
+)
+
+# Try common locations
+for _candidate in [
+    '/tmp/txn-visual-test',
+    '/private/tmp/txn-visual-test',
+    os.path.abspath('.'),
+    os.path.abspath('..'),
+]:
+    if os.path.isdir(os.path.join(_candidate, '22-executive')):
+        PPTX_BASE_PATH = _candidate
+        break
+
+# Ensure dashboard package is importable
+if PPTX_BASE_PATH not in sys.path:
+    sys.path.insert(0, PPTX_BASE_PATH)
+
+# Pre-captured images (if any cells called register_chart earlier)
+pptx_fig_registry = {}
+
+print("PPTX Export Setup")
+print("=" * 60)
+print(f"  Cell files root: {PPTX_BASE_PATH}")
+print(f"  Dashboard package: {os.path.join(PPTX_BASE_PATH, 'dashboard')}")
+
+# Verify dashboard package
+try:
+    from dashboard.storyline_config import STORYLINES, PRESENTATION_ORDER
+    from dashboard.pptx_engine import export_storyline, export_all_storylines
+    print(f"  Storylines loaded: {len(STORYLINES)}")
+    for key in PRESENTATION_ORDER:
+        cfg = STORYLINES[key]
+        _chart_ct = sum(1 for s in cfg['slides'] if s['type'] == 'chart')
+        print(f"    {cfg['id']}. {cfg['title']} "
+              f"({cfg['type']}, {len(cfg['slides'])} slides, {_chart_ct} charts)")
+    print(f"\n  Ready. Run the next cell (11_pptx_export) to generate decks.")
+except ImportError as e:
+    print(f"\n  ERROR: Could not import dashboard package: {e}")
+    print(f"  Make sure {PPTX_BASE_PATH}/dashboard/ exists with:")
+    print(f"    __init__.py, storyline_config.py, pptx_engine.py")
+
+print("=" * 60)

--- a/22-executive/11_pptx_01_executive_health_check
+++ b/22-executive/11_pptx_01_executive_health_check
@@ -1,0 +1,102 @@
+# ===========================================================================
+# PPTX EXPORT: Executive Health Check (Storyline 1 of 7, CORE)
+# ===========================================================================
+# Exports a single storyline deck: "Executive Health Check"
+# Audience: CEO, Board, CFO
+# Requires: 10_pptx_figure_registry has already run
+#
+# Data sources: scorecard_df, attrition_df, rel_df, _grand_total
+
+import os
+
+from dashboard.storyline_config import STORYLINES
+from dashboard.pptx_engine import export_storyline
+
+_STORYLINE_KEY = "executive_health_check"
+_config = STORYLINES[_STORYLINE_KEY]
+
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+print(f"PPTX Export: {_config['title']}")
+print("=" * 60)
+print(f"  Type:     {_config['type']}")
+print(f"  Audience: {_config['audience']}")
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values relevant to Executive Health Check
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'scorecard_df' in dir() and len(scorecard_df) > 0:
+    _kpi_values['Green KPIs'] = str(int((scorecard_df['rag'] == 'Green').sum()))
+    _kpi_values['Amber KPIs'] = str(int((scorecard_df['rag'] == 'Amber').sum()))
+    _kpi_values['Red KPIs'] = str(int((scorecard_df['rag'] == 'Red').sum()))
+
+if 'attrition_df' in dir() and len(attrition_df) > 0:
+    _ar = attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])]
+    _kpi_values['At Risk'] = f"{len(_ar) / len(attrition_df) * 100:.1f}%"
+
+if '_grand_total' in dir() and _grand_total > 0:
+    _kpi_values['Total Opportunity'] = gen_fmt_dollar(_grand_total, None)
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings for executive overview
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'scorecard_df' in dir() and len(scorecard_df) > 0:
+    _nr = int((scorecard_df['rag'] == 'Red').sum())
+    _na = int((scorecard_df['rag'] == 'Amber').sum())
+    _ng = int((scorecard_df['rag'] == 'Green').sum())
+    _findings.append(
+        f"{_nr} RED, {_na} AMBER, {_ng} GREEN across {len(scorecard_df)} KPIs"
+    )
+
+if 'attrition_df' in dir() and len(attrition_df) > 0:
+    _ar_ct = len(attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])])
+    _findings.append(
+        f"{_ar_ct / len(attrition_df) * 100:.1f}% of accounts at risk "
+        f"({_ar_ct:,} accounts)"
+    )
+
+if 'rel_df' in dir() and len(rel_df) > 0 and 'product_count' in rel_df.columns:
+    _sp = (rel_df['product_count'] == 1).sum()
+    _findings.append(f"{_sp:,} single-product members represent cross-sell opportunity")
+
+if '_grand_total' in dir() and _grand_total > 0:
+    _findings.append(f"Combined revenue opportunity: {gen_fmt_dollar(_grand_total, None)}")
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+try:
+    _path = export_storyline(
+        storyline_key=_STORYLINE_KEY,
+        fig_registry=pptx_fig_registry,
+        kpi_values=_kpi_values,
+        findings=_findings,
+        cu_name=_cu_name,
+        dataset_label=_dataset_label,
+        csm_name=_csm_name,
+        output_dir=EXPORT_DIR,
+        notebook_globals=globals(),
+        base_path=PPTX_BASE_PATH,
+    )
+    _size = os.path.getsize(_path) / 1024
+    print(f"\n{'='*60}")
+    print(f"  EXPORT COMPLETE: {_config['title']}")
+    print(f"  File: {os.path.basename(_path)} ({_size:.0f} KB)")
+    print(f"  Path: {_path}")
+    print(f"{'='*60}")
+except Exception as e:
+    print(f"\n  FAILED: {_STORYLINE_KEY} -- {e}")
+    print(f"{'='*60}")

--- a/22-executive/11_pptx_02_competitive_threat
+++ b/22-executive/11_pptx_02_competitive_threat
@@ -1,0 +1,111 @@
+# ===========================================================================
+# PPTX EXPORT: Competitive Threat & Wallet Share (Storyline 2 of 7, CORE)
+# ===========================================================================
+# Exports a single storyline deck: "Competitive Threat & Wallet Share"
+# Audience: CEO, VP Marketing, VP Ops
+# Requires: 10_pptx_figure_registry has already run
+#
+# Data sources: comp_df (competitor detection), finserv_df
+
+import os
+
+from dashboard.storyline_config import STORYLINES
+from dashboard.pptx_engine import export_storyline
+
+_STORYLINE_KEY = "competitive_threat"
+_config = STORYLINES[_STORYLINE_KEY]
+
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+print(f"PPTX Export: {_config['title']}")
+print("=" * 60)
+print(f"  Type:     {_config['type']}")
+print(f"  Audience: {_config['audience']}")
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values relevant to Competitive Threat
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'comp_df' in dir() and len(comp_df) > 0:
+    _with_comp = comp_df['has_competitor'].sum() if 'has_competitor' in comp_df.columns else 0
+    if _with_comp > 0:
+        _kpi_values['With Competitor'] = f"{_with_comp / len(comp_df) * 100:.1f}%"
+
+    if 'wallet_segment' in comp_df.columns:
+        _heavy = (comp_df['wallet_segment'] == 'Competitor-Heavy').sum()
+        _kpi_values['Competitor-Heavy'] = f"{_heavy:,}"
+
+    if 'competitor_count' in comp_df.columns:
+        _n_competitors = comp_df['competitor_count'].max()
+        _kpi_values['Competitors Found'] = str(int(_n_competitors))
+
+if 'finserv_df' in dir() and len(finserv_df) > 0:
+    _ext = len(finserv_df[finserv_df['is_external'] == True]) if 'is_external' in finserv_df.columns else 0
+    if _ext > 0 and len(finserv_df) > 0:
+        _kpi_values['External FinServ'] = f"{_ext / len(finserv_df) * 100:.1f}%"
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings for competitive narrative
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'comp_df' in dir() and len(comp_df) > 0:
+    if 'has_competitor' in comp_df.columns:
+        _pct_comp = comp_df['has_competitor'].sum() / len(comp_df) * 100
+        _findings.append(
+            f"{_pct_comp:.1f}% of members transact at competing institutions"
+        )
+
+    if 'wallet_segment' in comp_df.columns:
+        _heavy = (comp_df['wallet_segment'] == 'Competitor-Heavy').sum()
+        _findings.append(
+            f"{_heavy:,} accounts in Competitor-Heavy tier (>50% wallet share elsewhere)"
+        )
+
+    if 'competitor_spend' in comp_df.columns:
+        _total_leak = comp_df['competitor_spend'].sum()
+        _findings.append(
+            f"Total spend at competitors: {gen_fmt_dollar(_total_leak, None)}"
+        )
+
+if 'finserv_df' in dir() and len(finserv_df) > 0 and 'is_external' in finserv_df.columns:
+    _ext_ct = (finserv_df['is_external'] == True).sum()
+    _findings.append(
+        f"{_ext_ct:,} external financial service transactions detected"
+    )
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+try:
+    _path = export_storyline(
+        storyline_key=_STORYLINE_KEY,
+        fig_registry=pptx_fig_registry,
+        kpi_values=_kpi_values,
+        findings=_findings,
+        cu_name=_cu_name,
+        dataset_label=_dataset_label,
+        csm_name=_csm_name,
+        output_dir=EXPORT_DIR,
+        notebook_globals=globals(),
+        base_path=PPTX_BASE_PATH,
+    )
+    _size = os.path.getsize(_path) / 1024
+    print(f"\n{'='*60}")
+    print(f"  EXPORT COMPLETE: {_config['title']}")
+    print(f"  File: {os.path.basename(_path)} ({_size:.0f} KB)")
+    print(f"  Path: {_path}")
+    print(f"{'='*60}")
+except Exception as e:
+    print(f"\n  FAILED: {_STORYLINE_KEY} -- {e}")
+    print(f"{'='*60}")

--- a/22-executive/11_pptx_03_retention_attrition
+++ b/22-executive/11_pptx_03_retention_attrition
@@ -1,0 +1,124 @@
+# ===========================================================================
+# PPTX EXPORT: Member Retention & Attrition Risk (Storyline 3 of 7, CORE)
+# ===========================================================================
+# Exports a single storyline deck: "Member Retention & Attrition Risk"
+# Audience: VP Member Experience, CEO, Retention Team
+# Requires: 10_pptx_figure_registry has already run
+#
+# Data sources: attrition_df, retention_df, migration_df
+
+import os
+
+from dashboard.storyline_config import STORYLINES
+from dashboard.pptx_engine import export_storyline
+
+_STORYLINE_KEY = "retention_attrition"
+_config = STORYLINES[_STORYLINE_KEY]
+
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+print(f"PPTX Export: {_config['title']}")
+print("=" * 60)
+print(f"  Type:     {_config['type']}")
+print(f"  Audience: {_config['audience']}")
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values relevant to Retention & Attrition
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'attrition_df' in dir() and len(attrition_df) > 0:
+    _ar = attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])]
+    _at_risk_pct = len(_ar) / len(attrition_df) * 100
+    _kpi_values['At Risk'] = f"{_at_risk_pct:.1f}%"
+
+    if 'last_12mo_spend' in attrition_df.columns:
+        _kpi_values['Spend at Risk'] = gen_fmt_dollar(
+            _ar['last_12mo_spend'].sum(), None
+        )
+
+    _dormant_ct = len(attrition_df[attrition_df['risk_tier'] == 'Dormant'])
+    _kpi_values['Dormant'] = f"{_dormant_ct:,}"
+
+    _declining_ct = len(attrition_df[attrition_df['risk_tier'] == 'Declining'])
+    _kpi_values['Declining'] = f"{_declining_ct:,}"
+
+if 'retention_df' in dir() and len(retention_df) > 0:
+    if 'is_closed' in retention_df.columns:
+        _closed_rate = retention_df['is_closed'].mean() * 100
+        _kpi_values['Closed Rate'] = f"{_closed_rate:.1f}%"
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings for retention narrative
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'attrition_df' in dir() and len(attrition_df) > 0:
+    _ar_ct = len(attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])])
+    _findings.append(
+        f"{_ar_ct / len(attrition_df) * 100:.1f}% of accounts at risk "
+        f"({_ar_ct:,} accounts)"
+    )
+
+    if 'last_12mo_spend' in attrition_df.columns:
+        _spend_at_risk = attrition_df[
+            attrition_df['risk_tier'].isin(['Declining', 'Dormant'])
+        ]['last_12mo_spend'].sum()
+        _findings.append(
+            f"Annual spend at risk: {gen_fmt_dollar(_spend_at_risk, None)}"
+        )
+
+    if 'spend_velocity' in attrition_df.columns:
+        _avg_vel = attrition_df[
+            attrition_df['risk_tier'] == 'Declining'
+        ]['spend_velocity'].mean()
+        _findings.append(
+            f"Declining members average {_avg_vel:.2f}x spend velocity "
+            f"(velocity detection catches them 30-60 days before dormancy)"
+        )
+
+if 'migration_df' in dir() and len(migration_df) > 0:
+    if 'direction' in migration_df.columns:
+        _upgrades = (migration_df['direction'] == 'upgrade').sum()
+        _downgrades = (migration_df['direction'] == 'downgrade').sum()
+        _net = _upgrades - _downgrades
+        _direction = "positive" if _net > 0 else "negative"
+        _findings.append(
+            f"Net engagement migration: {_direction} "
+            f"({_upgrades:,} upgrades vs {_downgrades:,} downgrades)"
+        )
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+try:
+    _path = export_storyline(
+        storyline_key=_STORYLINE_KEY,
+        fig_registry=pptx_fig_registry,
+        kpi_values=_kpi_values,
+        findings=_findings,
+        cu_name=_cu_name,
+        dataset_label=_dataset_label,
+        csm_name=_csm_name,
+        output_dir=EXPORT_DIR,
+        notebook_globals=globals(),
+        base_path=PPTX_BASE_PATH,
+    )
+    _size = os.path.getsize(_path) / 1024
+    print(f"\n{'='*60}")
+    print(f"  EXPORT COMPLETE: {_config['title']}")
+    print(f"  File: {os.path.basename(_path)} ({_size:.0f} KB)")
+    print(f"  Path: {_path}")
+    print(f"{'='*60}")
+except Exception as e:
+    print(f"\n  FAILED: {_STORYLINE_KEY} -- {e}")
+    print(f"{'='*60}")

--- a/22-executive/11_pptx_04_revenue_optimization
+++ b/22-executive/11_pptx_04_revenue_optimization
@@ -1,0 +1,123 @@
+# ===========================================================================
+# PPTX EXPORT: Revenue Optimization (Storyline 4 of 7, CORE)
+# ===========================================================================
+# Exports a single storyline deck: "Revenue Optimization"
+# Audience: CFO, VP Card Services, VP Payments
+# Requires: 10_pptx_figure_registry has already run
+#
+# Data sources: interchange_df, rege_df, payroll_df
+
+import os
+
+from dashboard.storyline_config import STORYLINES
+from dashboard.pptx_engine import export_storyline
+
+_STORYLINE_KEY = "revenue_optimization"
+_config = STORYLINES[_STORYLINE_KEY]
+
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+print(f"PPTX Export: {_config['title']}")
+print("=" * 60)
+print(f"  Type:     {_config['type']}")
+print(f"  Audience: {_config['audience']}")
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values relevant to Revenue Optimization
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'interchange_df' in dir() and len(interchange_df) > 0:
+    _td = interchange_df['total_sig_dollars'].sum() if 'total_sig_dollars' in interchange_df.columns else 0
+    _tp = interchange_df['total_pin_dollars'].sum() if 'total_pin_dollars' in interchange_df.columns else 0
+    if _td + _tp > 0:
+        _kpi_values['SIG Ratio'] = f"{_td / (_td + _tp) * 100:.1f}%"
+
+    if 'annual_ic_revenue' in dir():
+        _kpi_values['Annual IC'] = gen_fmt_dollar(annual_ic_revenue, None)
+    elif 'total_sig_dollars' in interchange_df.columns:
+        _est_ic = _td * 0.015 + _tp * 0.005
+        _kpi_values['Est. IC Revenue'] = gen_fmt_dollar(_est_ic, None)
+
+    if 'pin_shift_gain' in dir():
+        _kpi_values['PIN Shift Gain'] = gen_fmt_dollar(pin_shift_gain, None)
+
+if 'rege_df' in dir() and len(rege_df) > 0:
+    _oi = len(rege_df[rege_df['current_status'] == 'Opted-In'])
+    _kpi_values['Reg E Opt-In'] = f"{_oi / len(rege_df) * 100:.1f}%"
+
+if 'payroll_df' in dir() and len(payroll_df) > 0 and 'has_payroll' in payroll_df.columns:
+    _kpi_values['Payroll DD'] = f"{payroll_df['has_payroll'].sum() / len(payroll_df) * 100:.1f}%"
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings for revenue narrative
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'interchange_df' in dir() and len(interchange_df) > 0:
+    _td = interchange_df['total_sig_dollars'].sum() if 'total_sig_dollars' in interchange_df.columns else 0
+    _tp = interchange_df['total_pin_dollars'].sum() if 'total_pin_dollars' in interchange_df.columns else 0
+    if _td + _tp > 0:
+        _sig_ratio = _td / (_td + _tp) * 100
+        _findings.append(
+            f"Signature ratio at {_sig_ratio:.1f}% -- "
+            f"every 10% PIN-to-SIG shift generates additional interchange"
+        )
+
+    if 'total_pin_dollars' in interchange_df.columns:
+        _pin_heavy = (interchange_df['total_pin_dollars'] > interchange_df.get('total_sig_dollars', 0)).sum() \
+            if 'total_sig_dollars' in interchange_df.columns else 0
+        if _pin_heavy > 0:
+            _findings.append(
+                f"{_pin_heavy:,} PIN-heavy accounts represent conversion opportunity"
+            )
+
+if 'rege_df' in dir() and len(rege_df) > 0:
+    _oi = len(rege_df[rege_df['current_status'] == 'Opted-In'])
+    _optin_pct = _oi / len(rege_df) * 100
+    _not_opted = len(rege_df) - _oi
+    _findings.append(
+        f"Reg E opt-in at {_optin_pct:.1f}% -- "
+        f"{_not_opted:,} eligible members not yet opted in"
+    )
+
+if 'payroll_df' in dir() and len(payroll_df) > 0 and 'has_payroll' in payroll_df.columns:
+    _payroll_pct = payroll_df['has_payroll'].sum() / len(payroll_df) * 100
+    _findings.append(
+        f"Payroll direct deposit detected for {_payroll_pct:.1f}% of accounts"
+    )
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+try:
+    _path = export_storyline(
+        storyline_key=_STORYLINE_KEY,
+        fig_registry=pptx_fig_registry,
+        kpi_values=_kpi_values,
+        findings=_findings,
+        cu_name=_cu_name,
+        dataset_label=_dataset_label,
+        csm_name=_csm_name,
+        output_dir=EXPORT_DIR,
+        notebook_globals=globals(),
+        base_path=PPTX_BASE_PATH,
+    )
+    _size = os.path.getsize(_path) / 1024
+    print(f"\n{'='*60}")
+    print(f"  EXPORT COMPLETE: {_config['title']}")
+    print(f"  File: {os.path.basename(_path)} ({_size:.0f} KB)")
+    print(f"  Path: {_path}")
+    print(f"{'='*60}")
+except Exception as e:
+    print(f"\n  FAILED: {_STORYLINE_KEY} -- {e}")
+    print(f"{'='*60}")

--- a/22-executive/11_pptx_05_relationship_growth
+++ b/22-executive/11_pptx_05_relationship_growth
@@ -1,0 +1,121 @@
+# ===========================================================================
+# PPTX EXPORT: Relationship Depth & Growth (Storyline 5 of 7, CORE)
+# ===========================================================================
+# Exports a single storyline deck: "Relationship Depth & Growth"
+# Audience: VP Lending, VP Deposits, CEO, Product Team
+# Requires: 10_pptx_figure_registry has already run
+#
+# Data sources: rel_df, payroll_df, balance_df
+
+import os
+
+from dashboard.storyline_config import STORYLINES
+from dashboard.pptx_engine import export_storyline
+
+_STORYLINE_KEY = "relationship_growth"
+_config = STORYLINES[_STORYLINE_KEY]
+
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+print(f"PPTX Export: {_config['title']}")
+print("=" * 60)
+print(f"  Type:     {_config['type']}")
+print(f"  Audience: {_config['audience']}")
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values relevant to Relationship Growth
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'rel_df' in dir() and len(rel_df) > 0 and 'product_count' in rel_df.columns:
+    _kpi_values['Avg Products'] = f"{rel_df['product_count'].mean():.2f}"
+
+    _sp = (rel_df['product_count'] == 1).sum()
+    _sp_pct = _sp / len(rel_df) * 100
+    _kpi_values['Single-Product'] = f"{_sp_pct:.1f}%"
+
+    _deep = (rel_df['product_count'] >= 3).sum()
+    _kpi_values['3+ Products'] = f"{_deep:,}"
+
+if 'payroll_df' in dir() and len(payroll_df) > 0 and 'has_payroll' in payroll_df.columns:
+    _kpi_values['Payroll DD'] = f"{payroll_df['has_payroll'].sum() / len(payroll_df) * 100:.1f}%"
+
+if 'balance_df' in dir() and len(balance_df) > 0 and 'avg_balance' in balance_df.columns:
+    _avg_bal = balance_df['avg_balance'].mean()
+    _kpi_values['Avg Balance'] = gen_fmt_dollar(_avg_bal, None)
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings for relationship narrative
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'rel_df' in dir() and len(rel_df) > 0 and 'product_count' in rel_df.columns:
+    _avg_prod = rel_df['product_count'].mean()
+    _findings.append(
+        f"Average {_avg_prod:.2f} products per member"
+    )
+
+    _sp = (rel_df['product_count'] == 1).sum()
+    _findings.append(
+        f"{_sp:,} single-product members represent cross-sell opportunity"
+    )
+
+    if 'total_balance' in rel_df.columns:
+        _bal_1 = rel_df[rel_df['product_count'] == 1]['total_balance'].mean()
+        _bal_3 = rel_df[rel_df['product_count'] >= 3]['total_balance'].mean()
+        if _bal_1 > 0:
+            _multiplier = _bal_3 / _bal_1
+            _findings.append(
+                f"Members with 3+ products hold {_multiplier:.1f}x higher balances"
+            )
+
+if 'payroll_df' in dir() and len(payroll_df) > 0 and 'has_payroll' in payroll_df.columns:
+    _payroll_pct = payroll_df['has_payroll'].sum() / len(payroll_df) * 100
+    _no_payroll = (~payroll_df['has_payroll']).sum()
+    _findings.append(
+        f"{_payroll_pct:.1f}% have payroll DD -- "
+        f"{_no_payroll:,} without payroll represent PFI growth opportunity"
+    )
+
+if 'balance_df' in dir() and len(balance_df) > 0:
+    if 'flight_risk' in balance_df.columns:
+        _at_risk_bal = balance_df[balance_df['flight_risk'] == True]['avg_balance'].sum()
+        _findings.append(
+            f"Deposit flight risk: {gen_fmt_dollar(_at_risk_bal, None)} "
+            f"in balances from declining-engagement members"
+        )
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+try:
+    _path = export_storyline(
+        storyline_key=_STORYLINE_KEY,
+        fig_registry=pptx_fig_registry,
+        kpi_values=_kpi_values,
+        findings=_findings,
+        cu_name=_cu_name,
+        dataset_label=_dataset_label,
+        csm_name=_csm_name,
+        output_dir=EXPORT_DIR,
+        notebook_globals=globals(),
+        base_path=PPTX_BASE_PATH,
+    )
+    _size = os.path.getsize(_path) / 1024
+    print(f"\n{'='*60}")
+    print(f"  EXPORT COMPLETE: {_config['title']}")
+    print(f"  File: {os.path.basename(_path)} ({_size:.0f} KB)")
+    print(f"  Path: {_path}")
+    print(f"{'='*60}")
+except Exception as e:
+    print(f"\n  FAILED: {_STORYLINE_KEY} -- {e}")
+    print(f"{'='*60}")

--- a/22-executive/11_pptx_06_ars_campaign
+++ b/22-executive/11_pptx_06_ars_campaign
@@ -1,0 +1,121 @@
+# ===========================================================================
+# PPTX EXPORT: ARS Campaign Performance (Storyline 6 of 7, SITUATIONAL)
+# ===========================================================================
+# Exports a single storyline deck: "ARS Campaign Performance"
+# Audience: VP Marketing, CEO, Board
+# Requires: 10_pptx_figure_registry has already run
+#
+# Data sources: ars_df (campaign data), cohort lift variables
+
+import os
+
+from dashboard.storyline_config import STORYLINES
+from dashboard.pptx_engine import export_storyline
+
+_STORYLINE_KEY = "ars_campaign"
+_config = STORYLINES[_STORYLINE_KEY]
+
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+print(f"PPTX Export: {_config['title']}")
+print("=" * 60)
+print(f"  Type:     {_config['type']}")
+print(f"  Audience: {_config['audience']}")
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values relevant to ARS Campaign
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'ars_df' in dir() and len(ars_df) > 0:
+    _kpi_values['Accounts Mailed'] = f"{len(ars_df):,}"
+
+    if 'is_responder' in ars_df.columns:
+        _resp = ars_df['is_responder'].sum()
+        _resp_rate = _resp / len(ars_df) * 100
+        _kpi_values['Response Rate'] = f"{_resp_rate:.1f}%"
+
+    if 'wave' in ars_df.columns:
+        _n_waves = ars_df['wave'].nunique()
+        _kpi_values['Waves'] = str(int(_n_waves))
+
+    if 'penetration_rate' in dir():
+        _kpi_values['Penetration'] = f"{penetration_rate:.1f}%"
+
+if 'avg_did_lift' in dir():
+    _kpi_values['DID Lift'] = gen_fmt_dollar(avg_did_lift, None)
+
+if 'persistence_rate' in dir():
+    _kpi_values['Persistence'] = f"{persistence_rate:.1f}%"
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings for campaign narrative
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'ars_df' in dir() and len(ars_df) > 0:
+    if 'is_responder' in ars_df.columns:
+        _resp = ars_df['is_responder'].sum()
+        _resp_rate = _resp / len(ars_df) * 100
+        _findings.append(
+            f"{_resp:,} responders from {len(ars_df):,} mailed "
+            f"({_resp_rate:.1f}% response rate)"
+        )
+
+    if 'wave' in ars_df.columns:
+        _n_waves = ars_df['wave'].nunique()
+        _findings.append(f"Campaign spans {_n_waves} mailing waves")
+
+if 'avg_did_lift' in dir() and avg_did_lift > 0:
+    _findings.append(
+        f"DID lift: +{gen_fmt_dollar(avg_did_lift, None)}/mo/account "
+        f"above counterfactual -- causal spend increase from mailer"
+    )
+
+if 'persistence_rate' in dir() and persistence_rate > 0:
+    _findings.append(
+        f"Spend lift persists at {persistence_rate:.1f}% beyond initial activation"
+    )
+
+if 'cumulative_lift' in dir() and cumulative_lift > 0:
+    _findings.append(
+        f"Cumulative incremental spend: {gen_fmt_dollar(cumulative_lift, None)}"
+    )
+
+if 'best_segment' in dir() and best_segment:
+    _findings.append(f"Highest ROI segment: {best_segment}")
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+try:
+    _path = export_storyline(
+        storyline_key=_STORYLINE_KEY,
+        fig_registry=pptx_fig_registry,
+        kpi_values=_kpi_values,
+        findings=_findings,
+        cu_name=_cu_name,
+        dataset_label=_dataset_label,
+        csm_name=_csm_name,
+        output_dir=EXPORT_DIR,
+        notebook_globals=globals(),
+        base_path=PPTX_BASE_PATH,
+    )
+    _size = os.path.getsize(_path) / 1024
+    print(f"\n{'='*60}")
+    print(f"  EXPORT COMPLETE: {_config['title']}")
+    print(f"  File: {os.path.basename(_path)} ({_size:.0f} KB)")
+    print(f"  Path: {_path}")
+    print(f"{'='*60}")
+except Exception as e:
+    print(f"\n  FAILED: {_STORYLINE_KEY} -- {e}")
+    print(f"{'='*60}")

--- a/22-executive/11_pptx_07_portfolio_intelligence
+++ b/22-executive/11_pptx_07_portfolio_intelligence
@@ -1,0 +1,123 @@
+# ===========================================================================
+# PPTX EXPORT: Portfolio Intelligence & Spending (Storyline 7 of 7, SITUATIONAL)
+# ===========================================================================
+# Exports a single storyline deck: "Portfolio Intelligence & Spending"
+# Audience: VP Marketing, VP Ops, Branch Managers
+# Requires: 10_pptx_figure_registry has already run
+#
+# Data sources: gen_df (general portfolio), mcc_df, segment_df
+
+import os
+
+from dashboard.storyline_config import STORYLINES
+from dashboard.pptx_engine import export_storyline
+
+_STORYLINE_KEY = "portfolio_intelligence"
+_config = STORYLINES[_STORYLINE_KEY]
+
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+print(f"PPTX Export: {_config['title']}")
+print("=" * 60)
+print(f"  Type:     {_config['type']}")
+print(f"  Audience: {_config['audience']}")
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values relevant to Portfolio Intelligence
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'gen_df' in dir() and len(gen_df) > 0:
+    _kpi_values['Total Accounts'] = f"{len(gen_df):,}"
+
+    if 'total_spend' in gen_df.columns:
+        _total_spend = gen_df['total_spend'].sum()
+        _kpi_values['Total Spend'] = gen_fmt_dollar(_total_spend, None)
+
+    if 'merchant_name' in gen_df.columns:
+        _n_merchants = gen_df['merchant_name'].nunique()
+        _kpi_values['Merchants'] = f"{_n_merchants:,}"
+
+if 'mcc_df' in dir() and len(mcc_df) > 0:
+    if 'mcc_category' in mcc_df.columns:
+        _n_cats = mcc_df['mcc_category'].nunique()
+        _kpi_values['Categories'] = str(int(_n_cats))
+
+if 'segment_df' in dir() and len(segment_df) > 0:
+    if 'segment_change' in segment_df.columns:
+        _upgraded = (segment_df['segment_change'] == 'upgrade').sum()
+        _total_seg = len(segment_df)
+        if _total_seg > 0:
+            _kpi_values['Upgraded'] = f"{_upgraded / _total_seg * 100:.1f}%"
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings for portfolio intelligence narrative
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'gen_df' in dir() and len(gen_df) > 0:
+    _findings.append(f"{len(gen_df):,} accounts in the analysis portfolio")
+
+    if 'total_spend' in gen_df.columns:
+        _total_spend = gen_df['total_spend'].sum()
+        _findings.append(f"Total portfolio spend: {gen_fmt_dollar(_total_spend, None)}")
+
+if 'mcc_df' in dir() and len(mcc_df) > 0 and 'mcc_category' in mcc_df.columns:
+    if 'total_amount' in mcc_df.columns:
+        _top_cats = mcc_df.groupby('mcc_category')['total_amount'].sum().nlargest(3)
+        _top_names = ", ".join(_top_cats.index.tolist())
+        _findings.append(f"Top spending categories: {_top_names}")
+
+if 'segment_df' in dir() and len(segment_df) > 0:
+    if 'segment_change' in segment_df.columns:
+        _upgraded = (segment_df['segment_change'] == 'upgrade').sum()
+        _degraded = (segment_df['segment_change'] == 'downgrade').sum()
+        _findings.append(
+            f"Segment migration: {_upgraded:,} upgraded vs "
+            f"{_degraded:,} degraded engagement tiers"
+        )
+
+if 'gen_df' in dir() and 'first_txn_days' in gen_df.columns:
+    _median_ttf = gen_df['first_txn_days'].median()
+    _findings.append(
+        f"New accounts activate within {_median_ttf:.0f} days (median)"
+    )
+
+if 'gen_df' in dir() and 'age_band' in gen_df.columns:
+    _top_gen = gen_df['age_band'].value_counts().idxmax()
+    _findings.append(f"Largest demographic segment: {_top_gen}")
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+try:
+    _path = export_storyline(
+        storyline_key=_STORYLINE_KEY,
+        fig_registry=pptx_fig_registry,
+        kpi_values=_kpi_values,
+        findings=_findings,
+        cu_name=_cu_name,
+        dataset_label=_dataset_label,
+        csm_name=_csm_name,
+        output_dir=EXPORT_DIR,
+        notebook_globals=globals(),
+        base_path=PPTX_BASE_PATH,
+    )
+    _size = os.path.getsize(_path) / 1024
+    print(f"\n{'='*60}")
+    print(f"  EXPORT COMPLETE: {_config['title']}")
+    print(f"  File: {os.path.basename(_path)} ({_size:.0f} KB)")
+    print(f"  Path: {_path}")
+    print(f"{'='*60}")
+except Exception as e:
+    print(f"\n  FAILED: {_STORYLINE_KEY} -- {e}")
+    print(f"{'='*60}")

--- a/22-executive/11_pptx_export
+++ b/22-executive/11_pptx_export
@@ -1,0 +1,155 @@
+# ===========================================================================
+# PPTX EXPORT: Generate storyline PowerPoint decks
+# ===========================================================================
+# Run AFTER all analysis cells and 10_pptx_figure_registry.
+#
+# HOW IT WORKS:
+#   For each chart slide in a storyline, the engine re-executes the
+#   referenced cell file using exec() in the notebook's namespace.
+#   plt.show() is monkey-patched to savefig() instead of displaying,
+#   so each chart is captured to a PNG and inserted into the PPTX.
+#
+#   All DataFrames (attrition_df, interchange_df, rel_df, etc.),
+#   palettes (GEN_COLORS), and helpers (gen_fmt_dollar, gen_clean_axes)
+#   are available because they live in the notebook's globals().
+#
+# CONFIGURATION:
+#   CU_NAME              -- credit union name (set in 00-setup)
+#   DATASET_LABEL        -- date range (set in 00-setup)
+#   CSM_NAME             -- presenter name (optional)
+#   EXPORT_DIR           -- output directory (default: ./pptx_output)
+#   STORYLINES_TO_EXPORT -- "all", "core", or list of storyline keys
+
+import os
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+_cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
+_dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
+_csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
+
+EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
+os.makedirs(EXPORT_DIR, exist_ok=True)
+
+# "all" = all 7 decks, "core" = 5 CORE only, or list like ["executive_health_check"]
+STORYLINES_TO_EXPORT = "core"
+
+print("PPTX Storyline Export")
+print("=" * 60)
+print(f"  CU:       {_cu_name}")
+print(f"  Dataset:  {_dataset_label}")
+print(f"  CSM:      {_csm_name or '(not set)'}")
+print(f"  Output:   {EXPORT_DIR}")
+print(f"  Scope:    {STORYLINES_TO_EXPORT}")
+
+# ---------------------------------------------------------------------------
+# Build KPI values from upstream data
+# ---------------------------------------------------------------------------
+_kpi_values = {}
+
+if 'scorecard_df' in dir() and len(scorecard_df) > 0:
+    _kpi_values['Green KPIs'] = str(int((scorecard_df['rag'] == 'Green').sum()))
+    _kpi_values['Amber KPIs'] = str(int((scorecard_df['rag'] == 'Amber').sum()))
+    _kpi_values['Red KPIs'] = str(int((scorecard_df['rag'] == 'Red').sum()))
+
+if 'attrition_df' in dir() and len(attrition_df) > 0:
+    _ar = attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])]
+    _kpi_values['At Risk'] = f"{len(_ar) / len(attrition_df) * 100:.1f}%"
+    if 'last_12mo_spend' in attrition_df.columns:
+        _kpi_values['Spend at Risk'] = gen_fmt_dollar(_ar['last_12mo_spend'].sum(), None)
+
+if 'interchange_df' in dir() and len(interchange_df) > 0:
+    _td = interchange_df['total_sig_dollars'].sum() if 'total_sig_dollars' in interchange_df.columns else 0
+    _tp = interchange_df['total_pin_dollars'].sum() if 'total_pin_dollars' in interchange_df.columns else 0
+    if _td + _tp > 0:
+        _kpi_values['SIG Ratio'] = f"{_td / (_td + _tp) * 100:.1f}%"
+
+if 'rel_df' in dir() and len(rel_df) > 0 and 'product_count' in rel_df.columns:
+    _kpi_values['Avg Products'] = f"{rel_df['product_count'].mean():.2f}"
+
+if 'payroll_df' in dir() and len(payroll_df) > 0 and 'has_payroll' in payroll_df.columns:
+    _kpi_values['Payroll DD'] = f"{payroll_df['has_payroll'].sum() / len(payroll_df) * 100:.1f}%"
+
+if 'rege_df' in dir() and len(rege_df) > 0:
+    _oi = len(rege_df[rege_df['current_status'] == 'Opted-In'])
+    _kpi_values['Reg E Opt-In'] = f"{_oi / len(rege_df) * 100:.1f}%"
+
+print(f"  KPIs:     {len(_kpi_values)} populated")
+
+# ---------------------------------------------------------------------------
+# Build findings
+# ---------------------------------------------------------------------------
+_findings = []
+
+if 'scorecard_df' in dir() and len(scorecard_df) > 0:
+    _nr = int((scorecard_df['rag'] == 'Red').sum())
+    _na = int((scorecard_df['rag'] == 'Amber').sum())
+    _ng = int((scorecard_df['rag'] == 'Green').sum())
+    _findings.append(f"{_nr} RED, {_na} AMBER, {_ng} GREEN across {len(scorecard_df)} KPIs")
+
+if 'attrition_df' in dir() and len(attrition_df) > 0:
+    _ar_ct = len(attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])])
+    _findings.append(f"{_ar_ct / len(attrition_df) * 100:.1f}% of accounts at risk ({_ar_ct:,} accounts)")
+
+if 'rel_df' in dir() and len(rel_df) > 0 and 'product_count' in rel_df.columns:
+    _sp = (rel_df['product_count'] == 1).sum()
+    _findings.append(f"{_sp:,} single-product members represent cross-sell opportunity")
+
+if '_grand_total' in dir() and _grand_total > 0:
+    _findings.append(f"Combined revenue opportunity: {gen_fmt_dollar(_grand_total, None)}")
+
+# ---------------------------------------------------------------------------
+# Resolve storylines
+# ---------------------------------------------------------------------------
+from dashboard.storyline_config import PRESENTATION_ORDER, STORYLINES, CORE_STORYLINES
+
+if STORYLINES_TO_EXPORT == "all":
+    _export_keys = list(PRESENTATION_ORDER)
+elif STORYLINES_TO_EXPORT == "core":
+    _export_keys = [k for k in PRESENTATION_ORDER if k in CORE_STORYLINES]
+elif isinstance(STORYLINES_TO_EXPORT, list):
+    _export_keys = STORYLINES_TO_EXPORT
+else:
+    _export_keys = [STORYLINES_TO_EXPORT]
+
+print(f"\n  Exporting {len(_export_keys)} deck(s)...")
+print(f"{'='*60}")
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+from dashboard.pptx_engine import export_storyline
+
+_exported = []
+
+for key in _export_keys:
+    try:
+        path = export_storyline(
+            storyline_key=key,
+            fig_registry=pptx_fig_registry,
+            kpi_values=_kpi_values,
+            findings=_findings,
+            cu_name=_cu_name,
+            dataset_label=_dataset_label,
+            csm_name=_csm_name,
+            output_dir=EXPORT_DIR,
+            notebook_globals=globals(),
+            base_path=PPTX_BASE_PATH,
+        )
+        _exported.append(path)
+    except Exception as e:
+        print(f"    FAILED: {key} -- {e}")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{'='*60}")
+print(f"  EXPORT COMPLETE")
+print(f"{'='*60}")
+print(f"  Decks generated: {len(_exported)}")
+print(f"  Output: {EXPORT_DIR}")
+for p in _exported:
+    _size = os.path.getsize(p) / 1024
+    print(f"    {os.path.basename(p)} ({_size:.0f} KB)")
+print(f"{'='*60}")

--- a/22-executive/12_pptx_export_all
+++ b/22-executive/12_pptx_export_all
@@ -1,30 +1,23 @@
 # ===========================================================================
-# PPTX EXPORT: Generate storyline PowerPoint decks
+# PPTX EXPORT ALL: Generate all storyline decks in batch
 # ===========================================================================
-# Run AFTER all analysis cells and 10_pptx_figure_registry.
+# Convenience cell that exports all 7 storyline decks (or core-only).
+# Equivalent to the original 11_pptx_export monolithic behavior.
 #
-# HOW IT WORKS:
-#   For each chart slide in a storyline, the engine re-executes the
-#   referenced cell file using exec() in the notebook's namespace.
-#   plt.show() is monkey-patched to savefig() instead of displaying,
-#   so each chart is captured to a PNG and inserted into the PPTX.
+# Run AFTER 10_pptx_figure_registry. All DataFrames must be in scope.
 #
-#   All DataFrames (attrition_df, interchange_df, rel_df, etc.),
-#   palettes (GEN_COLORS), and helpers (gen_fmt_dollar, gen_clean_axes)
-#   are available because they live in the notebook's globals().
-#
-# CONFIGURATION:
-#   CU_NAME              -- credit union name (set in 00-setup)
-#   DATASET_LABEL        -- date range (set in 00-setup)
-#   CSM_NAME             -- presenter name (optional)
-#   EXPORT_DIR           -- output directory (default: ./pptx_output)
-#   STORYLINES_TO_EXPORT -- "all", "core", or list of storyline keys
+# Set STORYLINES_TO_EXPORT to control scope:
+#   "all"  = all 7 decks
+#   "core" = 5 CORE storylines only
+#   list   = specific storyline keys, e.g. ["executive_health_check"]
 
 import os
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
+from dashboard.storyline_config import (
+    PRESENTATION_ORDER, STORYLINES, CORE_STORYLINES,
+)
+from dashboard.pptx_engine import export_storyline
+
 _cu_name = CU_NAME if 'CU_NAME' in dir() else "Credit Union"
 _dataset_label = DATASET_LABEL if 'DATASET_LABEL' in dir() else "Analysis Period"
 _csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
@@ -32,10 +25,10 @@ _csm_name = CSM_NAME if 'CSM_NAME' in dir() else ""
 EXPORT_DIR = os.path.join(PPTX_BASE_PATH, 'pptx_output')
 os.makedirs(EXPORT_DIR, exist_ok=True)
 
-# "all" = all 7 decks, "core" = 5 CORE only, or list like ["executive_health_check"]
+# "all" = all 7 decks, "core" = 5 CORE only, or list of storyline keys
 STORYLINES_TO_EXPORT = "core"
 
-print("PPTX Storyline Export")
+print("PPTX Batch Storyline Export")
 print("=" * 60)
 print(f"  CU:       {_cu_name}")
 print(f"  Dataset:  {_dataset_label}")
@@ -44,7 +37,7 @@ print(f"  Output:   {EXPORT_DIR}")
 print(f"  Scope:    {STORYLINES_TO_EXPORT}")
 
 # ---------------------------------------------------------------------------
-# Build KPI values from upstream data
+# Build shared KPI values from upstream data
 # ---------------------------------------------------------------------------
 _kpi_values = {}
 
@@ -57,7 +50,9 @@ if 'attrition_df' in dir() and len(attrition_df) > 0:
     _ar = attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])]
     _kpi_values['At Risk'] = f"{len(_ar) / len(attrition_df) * 100:.1f}%"
     if 'last_12mo_spend' in attrition_df.columns:
-        _kpi_values['Spend at Risk'] = gen_fmt_dollar(_ar['last_12mo_spend'].sum(), None)
+        _kpi_values['Spend at Risk'] = gen_fmt_dollar(
+            _ar['last_12mo_spend'].sum(), None
+        )
 
 if 'interchange_df' in dir() and len(interchange_df) > 0:
     _td = interchange_df['total_sig_dollars'].sum() if 'total_sig_dollars' in interchange_df.columns else 0
@@ -78,7 +73,7 @@ if 'rege_df' in dir() and len(rege_df) > 0:
 print(f"  KPIs:     {len(_kpi_values)} populated")
 
 # ---------------------------------------------------------------------------
-# Build findings
+# Build shared findings
 # ---------------------------------------------------------------------------
 _findings = []
 
@@ -86,24 +81,31 @@ if 'scorecard_df' in dir() and len(scorecard_df) > 0:
     _nr = int((scorecard_df['rag'] == 'Red').sum())
     _na = int((scorecard_df['rag'] == 'Amber').sum())
     _ng = int((scorecard_df['rag'] == 'Green').sum())
-    _findings.append(f"{_nr} RED, {_na} AMBER, {_ng} GREEN across {len(scorecard_df)} KPIs")
+    _findings.append(
+        f"{_nr} RED, {_na} AMBER, {_ng} GREEN across {len(scorecard_df)} KPIs"
+    )
 
 if 'attrition_df' in dir() and len(attrition_df) > 0:
     _ar_ct = len(attrition_df[attrition_df['risk_tier'].isin(['Declining', 'Dormant'])])
-    _findings.append(f"{_ar_ct / len(attrition_df) * 100:.1f}% of accounts at risk ({_ar_ct:,} accounts)")
+    _findings.append(
+        f"{_ar_ct / len(attrition_df) * 100:.1f}% of accounts at risk "
+        f"({_ar_ct:,} accounts)"
+    )
 
 if 'rel_df' in dir() and len(rel_df) > 0 and 'product_count' in rel_df.columns:
     _sp = (rel_df['product_count'] == 1).sum()
-    _findings.append(f"{_sp:,} single-product members represent cross-sell opportunity")
+    _findings.append(
+        f"{_sp:,} single-product members represent cross-sell opportunity"
+    )
 
 if '_grand_total' in dir() and _grand_total > 0:
-    _findings.append(f"Combined revenue opportunity: {gen_fmt_dollar(_grand_total, None)}")
+    _findings.append(
+        f"Combined revenue opportunity: {gen_fmt_dollar(_grand_total, None)}"
+    )
 
 # ---------------------------------------------------------------------------
-# Resolve storylines
+# Resolve storylines to export
 # ---------------------------------------------------------------------------
-from dashboard.storyline_config import PRESENTATION_ORDER, STORYLINES, CORE_STORYLINES
-
 if STORYLINES_TO_EXPORT == "all":
     _export_keys = list(PRESENTATION_ORDER)
 elif STORYLINES_TO_EXPORT == "core":
@@ -117,10 +119,8 @@ print(f"\n  Exporting {len(_export_keys)} deck(s)...")
 print(f"{'='*60}")
 
 # ---------------------------------------------------------------------------
-# Export
+# Export loop
 # ---------------------------------------------------------------------------
-from dashboard.pptx_engine import export_storyline
-
 _exported = []
 
 for key in _export_keys:

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,3 @@
+# Dashboard package: storyline PPTX export infrastructure
+from dashboard.storyline_config import STORYLINES, PRESENTATION_ORDER
+from dashboard.pptx_engine import export_storyline, export_all_storylines

--- a/dashboard/pptx_engine.py
+++ b/dashboard/pptx_engine.py
@@ -1,0 +1,694 @@
+# ===========================================================================
+# PPTX ENGINE: PowerPoint export for storyline decks
+# ===========================================================================
+# Generates branded PPTX files from storyline configs using python-pptx.
+# Each slide receives a chart image (rendered from matplotlib figures),
+# a title bar, subtitle, and footer.
+
+import os
+import tempfile
+from datetime import datetime
+
+from pptx import Presentation
+from pptx.util import Inches, Pt, Emu
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+
+# ---------------------------------------------------------------------------
+# Brand constants (mapped from GEN_COLORS)
+# ---------------------------------------------------------------------------
+BRAND = {
+    "primary":   RGBColor(0x1B, 0x2A, 0x4A),  # deep navy
+    "accent":    RGBColor(0xE6, 0x39, 0x46),  # signal red
+    "success":   RGBColor(0x2E, 0xC4, 0xB6),  # teal
+    "warning":   RGBColor(0xFF, 0x9F, 0x1C),  # amber
+    "info":      RGBColor(0x45, 0x7B, 0x9D),  # steel blue
+    "dark_text": RGBColor(0x1B, 0x2A, 0x4A),  # navy
+    "muted":     RGBColor(0x6C, 0x75, 0x7D),  # gray
+    "white":     RGBColor(0xFF, 0xFF, 0xFF),
+    "light_bg":  RGBColor(0xF8, 0xF9, 0xFA),
+    "grid":      RGBColor(0xE9, 0xEC, 0xEF),
+}
+
+RAG_COLORS = {
+    "Green": RGBColor(0x2E, 0xC4, 0xB6),
+    "Amber": RGBColor(0xFF, 0x9F, 0x1C),
+    "Red":   RGBColor(0xE6, 0x39, 0x46),
+}
+
+# Slide dimensions (widescreen 16:9)
+SLIDE_WIDTH = Inches(13.333)
+SLIDE_HEIGHT = Inches(7.5)
+
+# Layout zones
+TITLE_BAR_HEIGHT = Inches(1.1)
+FOOTER_HEIGHT = Inches(0.45)
+CONTENT_TOP = Inches(1.2)
+CONTENT_LEFT = Inches(0.5)
+CONTENT_WIDTH = Inches(12.333)
+CONTENT_HEIGHT = SLIDE_HEIGHT - CONTENT_TOP - FOOTER_HEIGHT - Inches(0.2)
+
+# Font sizes
+TITLE_FONT_SIZE = Pt(28)
+SUBTITLE_FONT_SIZE = Pt(14)
+FOOTER_FONT_SIZE = Pt(10)
+KPI_VALUE_SIZE = Pt(36)
+KPI_LABEL_SIZE = Pt(12)
+BODY_FONT_SIZE = Pt(14)
+EXEC_SUMMARY_SIZE = Pt(16)
+MIN_FONT_SIZE = Pt(14)
+
+
+# ===========================================================================
+# Low-level slide builders
+# ===========================================================================
+
+def _set_slide_size(prs):
+    """Set presentation to widescreen 16:9."""
+    prs.slide_width = SLIDE_WIDTH
+    prs.slide_height = SLIDE_HEIGHT
+
+
+def _add_title_bar(slide, title_text, subtitle_text=None):
+    """Add a navy title bar to the top of a slide."""
+    # Title bar background
+    left, top = Inches(0), Inches(0)
+    width = SLIDE_WIDTH
+    height = TITLE_BAR_HEIGHT
+
+    shape = slide.shapes.add_shape(
+        1, left, top, width, height,  # 1 = rectangle
+    )
+    shape.fill.solid()
+    shape.fill.fore_color.rgb = BRAND["primary"]
+    shape.line.fill.background()
+
+    # Title text
+    txBox = slide.shapes.add_textbox(
+        Inches(0.5), Inches(0.15), SLIDE_WIDTH - Inches(1), Inches(0.6),
+    )
+    tf = txBox.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = title_text
+    p.font.size = TITLE_FONT_SIZE
+    p.font.bold = True
+    p.font.color.rgb = BRAND["white"]
+    p.alignment = PP_ALIGN.LEFT
+
+    # Subtitle
+    if subtitle_text:
+        txBox2 = slide.shapes.add_textbox(
+            Inches(0.5), Inches(0.72), SLIDE_WIDTH - Inches(1), Inches(0.35),
+        )
+        tf2 = txBox2.text_frame
+        tf2.word_wrap = True
+        p2 = tf2.paragraphs[0]
+        p2.text = subtitle_text
+        p2.font.size = SUBTITLE_FONT_SIZE
+        p2.font.italic = True
+        p2.font.color.rgb = RGBColor(0xA0, 0xB0, 0xC0)
+        p2.alignment = PP_ALIGN.LEFT
+
+
+def _add_footer(slide, dataset_label, slide_num, total_slides):
+    """Add footer with dataset label and page number."""
+    footer_top = SLIDE_HEIGHT - FOOTER_HEIGHT
+
+    # Left: dataset label
+    txBox = slide.shapes.add_textbox(
+        Inches(0.5), footer_top, Inches(8), FOOTER_HEIGHT,
+    )
+    tf = txBox.text_frame
+    tf.vertical_anchor = MSO_ANCHOR.MIDDLE
+    p = tf.paragraphs[0]
+    p.text = dataset_label
+    p.font.size = FOOTER_FONT_SIZE
+    p.font.color.rgb = BRAND["muted"]
+    p.font.italic = True
+    p.alignment = PP_ALIGN.LEFT
+
+    # Right: page number
+    txBox2 = slide.shapes.add_textbox(
+        SLIDE_WIDTH - Inches(2), footer_top, Inches(1.5), FOOTER_HEIGHT,
+    )
+    tf2 = txBox2.text_frame
+    tf2.vertical_anchor = MSO_ANCHOR.MIDDLE
+    p2 = tf2.paragraphs[0]
+    p2.text = f"{slide_num} / {total_slides}"
+    p2.font.size = FOOTER_FONT_SIZE
+    p2.font.color.rgb = BRAND["muted"]
+    p2.alignment = PP_ALIGN.RIGHT
+
+
+# ===========================================================================
+# Slide type builders
+# ===========================================================================
+
+def add_title_slide(prs, storyline_config, cu_name, dataset_label, csm_name=""):
+    """Create a branded title slide."""
+    slide_layout = prs.slide_layouts[6]  # blank layout
+    slide = prs.slides.add_slide(slide_layout)
+
+    # Full navy background
+    bg = slide.shapes.add_shape(
+        1, Inches(0), Inches(0), SLIDE_WIDTH, SLIDE_HEIGHT,
+    )
+    bg.fill.solid()
+    bg.fill.fore_color.rgb = BRAND["primary"]
+    bg.line.fill.background()
+
+    # Accent line
+    line = slide.shapes.add_shape(
+        1, Inches(1.5), Inches(3.0), Inches(10.333), Inches(0.04),
+    )
+    line.fill.solid()
+    line.fill.fore_color.rgb = BRAND["success"]
+    line.line.fill.background()
+
+    # Title
+    txBox = slide.shapes.add_textbox(
+        Inches(1.5), Inches(1.5), Inches(10.333), Inches(1.3),
+    )
+    tf = txBox.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = storyline_config["title"]
+    p.font.size = Pt(40)
+    p.font.bold = True
+    p.font.color.rgb = BRAND["white"]
+    p.alignment = PP_ALIGN.LEFT
+
+    # Tagline
+    txBox2 = slide.shapes.add_textbox(
+        Inches(1.5), Inches(3.2), Inches(10.333), Inches(0.6),
+    )
+    tf2 = txBox2.text_frame
+    tf2.word_wrap = True
+    p2 = tf2.paragraphs[0]
+    p2.text = storyline_config["tagline"]
+    p2.font.size = Pt(22)
+    p2.font.italic = True
+    p2.font.color.rgb = BRAND["success"]
+    p2.alignment = PP_ALIGN.LEFT
+
+    # CU name
+    txBox3 = slide.shapes.add_textbox(
+        Inches(1.5), Inches(4.5), Inches(10.333), Inches(0.5),
+    )
+    tf3 = txBox3.text_frame
+    p3 = tf3.paragraphs[0]
+    p3.text = cu_name
+    p3.font.size = Pt(20)
+    p3.font.bold = True
+    p3.font.color.rgb = BRAND["white"]
+    p3.alignment = PP_ALIGN.LEFT
+
+    # Dataset label + CSM
+    txBox4 = slide.shapes.add_textbox(
+        Inches(1.5), Inches(5.2), Inches(10.333), Inches(0.8),
+    )
+    tf4 = txBox4.text_frame
+    tf4.word_wrap = True
+    p4 = tf4.paragraphs[0]
+    parts = [dataset_label]
+    if csm_name:
+        parts.append(f"Presented by {csm_name}")
+    parts.append(datetime.now().strftime("%B %Y"))
+    p4.text = " | ".join(parts)
+    p4.font.size = Pt(14)
+    p4.font.color.rgb = RGBColor(0xA0, 0xB0, 0xC0)
+    p4.alignment = PP_ALIGN.LEFT
+
+    # Audience
+    txBox5 = slide.shapes.add_textbox(
+        Inches(1.5), Inches(6.2), Inches(10.333), Inches(0.4),
+    )
+    tf5 = txBox5.text_frame
+    p5 = tf5.paragraphs[0]
+    p5.text = f"Audience: {storyline_config['audience']}"
+    p5.font.size = Pt(11)
+    p5.font.color.rgb = BRAND["muted"]
+    p5.alignment = PP_ALIGN.LEFT
+
+    return slide
+
+
+def add_chart_slide(prs, title, subtitle, image_path,
+                    dataset_label, slide_num, total_slides):
+    """Add a slide with a chart image."""
+    slide_layout = prs.slide_layouts[6]  # blank
+    slide = prs.slides.add_slide(slide_layout)
+
+    _add_title_bar(slide, title, subtitle)
+    _add_footer(slide, dataset_label, slide_num, total_slides)
+
+    # Insert chart image centered in content area
+    if image_path and os.path.exists(image_path):
+        # Calculate dimensions to fit while maintaining aspect ratio
+        from PIL import Image as PILImage
+        try:
+            with PILImage.open(image_path) as img:
+                img_w, img_h = img.size
+        except Exception:
+            img_w, img_h = 1600, 900
+
+        aspect = img_w / img_h
+        max_w = CONTENT_WIDTH
+        max_h = CONTENT_HEIGHT
+
+        if aspect > (max_w / max_h):
+            # Width-constrained
+            final_w = max_w
+            final_h = int(max_w / aspect)
+        else:
+            # Height-constrained
+            final_h = max_h
+            final_w = int(max_h * aspect)
+
+        # Center horizontally
+        left = CONTENT_LEFT + (max_w - final_w) // 2
+        top = CONTENT_TOP
+
+        slide.shapes.add_picture(image_path, left, top, final_w, final_h)
+    else:
+        # Placeholder text when no image
+        txBox = slide.shapes.add_textbox(
+            CONTENT_LEFT, CONTENT_TOP + Inches(1.5),
+            CONTENT_WIDTH, Inches(1),
+        )
+        tf = txBox.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = "[Chart will be generated when notebook data is available]"
+        p.font.size = Pt(16)
+        p.font.color.rgb = BRAND["muted"]
+        p.font.italic = True
+        p.alignment = PP_ALIGN.CENTER
+
+    return slide
+
+
+def add_exec_summary_slide(prs, storyline_config, kpi_values, findings,
+                           dataset_label, slide_num, total_slides):
+    """Add an executive summary slide with KPI cards and key findings."""
+    slide_layout = prs.slide_layouts[6]
+    slide = prs.slides.add_slide(slide_layout)
+
+    _add_title_bar(slide, "Executive Summary",
+                   storyline_config.get("tagline", ""))
+    _add_footer(slide, dataset_label, slide_num, total_slides)
+
+    # KPI cards row (up to 4 cards across the top)
+    kpi_items = list(kpi_values.items())[:4]
+    n_cards = len(kpi_items) if kpi_items else 0
+
+    if n_cards > 0:
+        card_width = Inches(2.8)
+        card_height = Inches(1.6)
+        card_spacing = Inches(0.3)
+        total_card_width = (card_width * n_cards) + (card_spacing * (n_cards - 1))
+        start_left = CONTENT_LEFT + (CONTENT_WIDTH - total_card_width) // 2
+
+        for i, (label, value) in enumerate(kpi_items):
+            left = start_left + i * (card_width + card_spacing)
+            top = CONTENT_TOP + Inches(0.2)
+
+            # Card background
+            card = slide.shapes.add_shape(
+                5, left, top, card_width, card_height,  # 5 = rounded rectangle
+            )
+            card.fill.solid()
+            card.fill.fore_color.rgb = BRAND["light_bg"]
+            card.line.color.rgb = BRAND["grid"]
+            card.line.width = Pt(1)
+
+            # Value
+            vBox = slide.shapes.add_textbox(
+                left + Inches(0.1), top + Inches(0.2),
+                card_width - Inches(0.2), Inches(0.8),
+            )
+            vf = vBox.text_frame
+            vf.word_wrap = True
+            vp = vf.paragraphs[0]
+            vp.text = str(value)
+            vp.font.size = KPI_VALUE_SIZE
+            vp.font.bold = True
+            vp.font.color.rgb = BRAND["primary"]
+            vp.alignment = PP_ALIGN.CENTER
+
+            # Label
+            lBox = slide.shapes.add_textbox(
+                left + Inches(0.1), top + Inches(1.0),
+                card_width - Inches(0.2), Inches(0.5),
+            )
+            lf = lBox.text_frame
+            lf.word_wrap = True
+            lp = lf.paragraphs[0]
+            lp.text = label.replace("_", " ").title()
+            lp.font.size = KPI_LABEL_SIZE
+            lp.font.bold = True
+            lp.font.color.rgb = BRAND["muted"]
+            lp.alignment = PP_ALIGN.CENTER
+
+    # Key findings section
+    findings_top = CONTENT_TOP + Inches(2.2)
+    if findings:
+        # Section header
+        hBox = slide.shapes.add_textbox(
+            CONTENT_LEFT, findings_top, Inches(4), Inches(0.4),
+        )
+        hf = hBox.text_frame
+        hp = hf.paragraphs[0]
+        hp.text = "Key Findings"
+        hp.font.size = Pt(18)
+        hp.font.bold = True
+        hp.font.color.rgb = BRAND["dark_text"]
+
+        # Bullet points
+        bBox = slide.shapes.add_textbox(
+            CONTENT_LEFT + Inches(0.3), findings_top + Inches(0.5),
+            Inches(11), Inches(3),
+        )
+        bf = bBox.text_frame
+        bf.word_wrap = True
+
+        for j, finding in enumerate(findings[:6]):
+            p = bf.paragraphs[0] if j == 0 else bf.add_paragraph()
+            p.text = finding
+            p.font.size = EXEC_SUMMARY_SIZE
+            p.font.color.rgb = BRAND["dark_text"]
+            p.space_after = Pt(8)
+            p.level = 0
+
+    return slide
+
+
+def add_text_slide(prs, title, subtitle, body_lines,
+                   dataset_label, slide_num, total_slides):
+    """Add a text-only slide (next steps, data sources, recommendations)."""
+    slide_layout = prs.slide_layouts[6]
+    slide = prs.slides.add_slide(slide_layout)
+
+    _add_title_bar(slide, title, subtitle)
+    _add_footer(slide, dataset_label, slide_num, total_slides)
+
+    if body_lines:
+        txBox = slide.shapes.add_textbox(
+            CONTENT_LEFT + Inches(0.3), CONTENT_TOP + Inches(0.3),
+            CONTENT_WIDTH - Inches(0.6), CONTENT_HEIGHT - Inches(0.3),
+        )
+        tf = txBox.text_frame
+        tf.word_wrap = True
+
+        for i, line in enumerate(body_lines):
+            p = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
+            p.text = line
+            p.font.size = BODY_FONT_SIZE
+            p.font.color.rgb = BRAND["dark_text"]
+            p.space_after = Pt(10)
+
+    return slide
+
+
+# ===========================================================================
+# Figure capture: re-execute cell code with plt.show() intercepted
+# ===========================================================================
+
+def render_cell_to_png(cell_ref, notebook_globals, output_dir, base_path):
+    """Re-execute a cell file, intercept plt.show(), save figure to PNG.
+
+    How it works:
+    1. Read the cell source file from disk
+    2. Monkey-patch plt.show() to savefig + plt.close() instead of display
+    3. exec() the cell code using the notebook's live globals (so all
+       DataFrames, palettes, and helpers are available)
+    4. Restore plt.show()
+
+    Args:
+        cell_ref: e.g. "13-attrition/02_attrition_kpi"
+        notebook_globals: the notebook's globals() dict (contains all
+            DataFrames, GEN_COLORS, helper functions, etc.)
+        output_dir: directory for output PNGs
+        base_path: root path of the notebook cell files
+
+    Returns:
+        Path to saved PNG, or None on failure.
+    """
+    import matplotlib.pyplot as plt
+
+    cell_path = os.path.join(base_path, cell_ref)
+    if not os.path.isfile(cell_path):
+        return None
+
+    with open(cell_path, "r") as f:
+        source = f.read()
+
+    os.makedirs(output_dir, exist_ok=True)
+    safe_name = cell_ref.replace("/", "_").replace("-", "_")
+    png_path = os.path.join(output_dir, f"{safe_name}.png")
+
+    # Track whether a figure was saved
+    _captured = {"saved": False}
+
+    # Monkey-patch plt.show to save instead of display
+    _original_show = plt.show
+
+    def _capture_show(*args, **kwargs):
+        fig = plt.gcf()
+        if fig and fig.get_axes():
+            fig.savefig(png_path, dpi=300, bbox_inches="tight",
+                        facecolor="white", edgecolor="none")
+            _captured["saved"] = True
+        plt.close("all")
+
+    plt.show = _capture_show
+
+    # Suppress display() calls (for HTML table cells)
+    _original_display = notebook_globals.get("display")
+
+    def _noop_display(*args, **kwargs):
+        pass
+
+    try:
+        # Build exec namespace: notebook globals + our overrides
+        exec_ns = dict(notebook_globals)
+        exec_ns["display"] = _noop_display
+        exec_ns["plt"] = plt
+
+        exec(compile(source, cell_path, "exec"), exec_ns)
+
+        # Copy any new variables back to notebook globals so downstream
+        # cells that depend on computed values still work
+        for k, v in exec_ns.items():
+            if k not in ("__builtins__", "display", "plt"):
+                notebook_globals[k] = v
+
+    except Exception as e:
+        # Cell failed -- not fatal, just skip this chart
+        print(f"    WARNING: {cell_ref} failed: {e}")
+        png_path = None
+    finally:
+        plt.show = _original_show
+        if _original_display is not None:
+            notebook_globals["display"] = _original_display
+        plt.close("all")
+
+    if _captured["saved"] and png_path and os.path.exists(png_path):
+        return png_path
+    return None
+
+
+def resolve_chart_image(cell_ref, fig_registry, notebook_globals,
+                        output_dir, base_path):
+    """Get a chart PNG for a cell: use registry first, re-render if needed.
+
+    Args:
+        cell_ref: cell reference string
+        fig_registry: dict of cell_ref -> PNG path (pre-captured)
+        notebook_globals: notebook globals() for re-execution
+        output_dir: temp dir for PNGs
+        base_path: root path of cell files
+
+    Returns:
+        Path to PNG, or None.
+    """
+    # 1. Check if already in registry (pre-captured path)
+    existing = fig_registry.get(cell_ref)
+    if existing and os.path.exists(existing):
+        return existing
+
+    # 2. Re-render by executing the cell
+    if notebook_globals and base_path:
+        return render_cell_to_png(cell_ref, notebook_globals,
+                                  output_dir, base_path)
+
+    return None
+
+
+# ===========================================================================
+# Main export function
+# ===========================================================================
+
+def export_storyline(storyline_key, fig_registry=None, kpi_values=None,
+                     findings=None, text_content=None,
+                     cu_name="Credit Union", dataset_label="",
+                     csm_name="", output_dir=None,
+                     notebook_globals=None, base_path=None):
+    """Export a single storyline deck to PPTX.
+
+    Two modes of operation:
+    1. Pre-captured: pass fig_registry with cell_ref -> PNG path mappings
+    2. Re-render (recommended): pass notebook_globals=globals() and
+       base_path pointing to the cell files root. Each chart cell is
+       re-executed with plt.show() intercepted to save PNGs.
+
+    Mode 2 is the default Jupyter workflow. After running all analysis
+    cells, call this with notebook_globals=globals() and base_path set
+    to the txn-visual-test root. The engine re-runs each chart cell in
+    the notebook's namespace so all DataFrames are available.
+
+    Args:
+        storyline_key: key from STORYLINES dict
+        fig_registry: dict of cell_ref -> PNG path (optional)
+        kpi_values: dict of KPI label -> display value for exec summary
+        findings: list of finding strings for exec summary
+        text_content: dict of content_key -> list of body lines
+        cu_name: credit union name
+        dataset_label: date range string
+        csm_name: CSM presenter name
+        output_dir: directory for output PPTX
+        notebook_globals: the notebook's globals() dict for re-rendering
+        base_path: root directory of cell files (e.g., /tmp/txn-visual-test)
+
+    Returns:
+        Path to generated PPTX file.
+    """
+    from dashboard.storyline_config import STORYLINES
+
+    config = STORYLINES.get(storyline_key)
+    if config is None:
+        raise ValueError(f"Unknown storyline: {storyline_key}")
+
+    fig_registry = fig_registry or {}
+    kpi_values = kpi_values or {}
+    findings = findings or []
+    text_content = text_content or {}
+    output_dir = output_dir or os.getcwd()
+
+    prs = Presentation()
+    _set_slide_size(prs)
+
+    slides = config["slides"]
+    total_slides = len(slides)
+
+    # Temp dir for chart PNGs
+    tmp_dir = tempfile.mkdtemp(prefix="pptx_charts_")
+
+    _rendered = 0
+    _skipped = 0
+
+    for slide_def in slides:
+        slide_type = slide_def["type"]
+        num = slide_def["num"]
+
+        if slide_type == "title":
+            add_title_slide(prs, config, cu_name, dataset_label, csm_name)
+
+        elif slide_type == "exec_summary":
+            add_exec_summary_slide(
+                prs, config, kpi_values, findings,
+                dataset_label, num, total_slides,
+            )
+
+        elif slide_type == "chart":
+            cell_ref = slide_def.get("cell")
+            img_path = None
+            if cell_ref:
+                img_path = resolve_chart_image(
+                    cell_ref, fig_registry, notebook_globals,
+                    tmp_dir, base_path,
+                )
+                if img_path:
+                    _rendered += 1
+                else:
+                    _skipped += 1
+
+            add_chart_slide(
+                prs, slide_def["title"], slide_def.get("subtitle", ""),
+                img_path, dataset_label, num, total_slides,
+            )
+
+        elif slide_type == "text":
+            content_key = slide_def.get("content_key", "")
+            body = text_content.get(content_key, [
+                "Content to be customized by your CSM.",
+                "Please add specific action items and timelines.",
+            ])
+            add_text_slide(
+                prs, slide_def["title"], slide_def.get("subtitle", ""),
+                body, dataset_label, num, total_slides,
+            )
+
+    # Save PPTX
+    os.makedirs(output_dir, exist_ok=True)
+    safe_key = storyline_key.replace(" ", "_")
+    cu_safe = cu_name.replace(" ", "_").replace("/", "_")
+    timestamp = datetime.now().strftime("%Y%m%d")
+    filename = f"{config['id']:02d}_{safe_key}_{cu_safe}_{timestamp}.pptx"
+    filepath = os.path.join(output_dir, filename)
+
+    prs.save(filepath)
+    print(f"    {config['title']}: {_rendered} charts rendered, "
+          f"{_skipped} skipped, {total_slides} slides total")
+    return filepath
+
+
+def export_all_storylines(fig_registry=None, kpi_values=None,
+                          findings_by_storyline=None,
+                          text_content_by_storyline=None,
+                          cu_name="Credit Union", dataset_label="",
+                          csm_name="", output_dir=None,
+                          core_only=False,
+                          notebook_globals=None, base_path=None):
+    """Export all (or core-only) storyline decks.
+
+    Args:
+        fig_registry: dict of cell_ref -> PNG path (optional)
+        kpi_values: dict of KPI label -> display value (shared)
+        findings_by_storyline: dict of storyline_key -> list of findings
+        text_content_by_storyline: dict of storyline_key -> text_content dict
+        cu_name: credit union name
+        dataset_label: date range string
+        csm_name: CSM name
+        output_dir: output directory
+        core_only: if True, skip SITUATIONAL storylines
+        notebook_globals: notebook globals() for re-rendering charts
+        base_path: root directory of cell files
+
+    Returns:
+        List of generated PPTX file paths.
+    """
+    from dashboard.storyline_config import PRESENTATION_ORDER, STORYLINES
+
+    findings_by_storyline = findings_by_storyline or {}
+    text_content_by_storyline = text_content_by_storyline or {}
+    output_dir = output_dir or os.getcwd()
+
+    paths = []
+    for key in PRESENTATION_ORDER:
+        config = STORYLINES[key]
+        if core_only and config["type"] == "SITUATIONAL":
+            continue
+
+        findings = findings_by_storyline.get(key, [])
+        text_content = text_content_by_storyline.get(key, {})
+
+        path = export_storyline(
+            key, fig_registry, kpi_values, findings, text_content,
+            cu_name, dataset_label, csm_name, output_dir,
+            notebook_globals=notebook_globals, base_path=base_path,
+        )
+        paths.append(path)
+
+    return paths

--- a/dashboard/storyline_config.py
+++ b/dashboard/storyline_config.py
@@ -1,0 +1,1262 @@
+# ===========================================================================
+# STORYLINE CONFIGURATION: 7 narrative decks + master export registry
+# ===========================================================================
+# Each storyline defines slide order, titles, cell references, KPI keys,
+# and executive summary templates. Used by pptx_engine.py to build decks.
+
+STORYLINES = {}
+
+# ---------------------------------------------------------------------------
+# Storyline 1: Executive Health Check (CORE - always present)
+# ---------------------------------------------------------------------------
+STORYLINES["executive_health_check"] = {
+    "id": 1,
+    "title": "Executive Health Check",
+    "tagline": "Your Portfolio at a Glance",
+    "type": "CORE",
+    "audience": "CEO, Board, CFO",
+    "duration_min": 15,
+    "slides": [
+        {
+            "num": 1,
+            "title": "Executive Health Check",
+            "subtitle": "Your Portfolio at a Glance",
+            "type": "title",
+            "cell": None,
+        },
+        {
+            "num": 2,
+            "title": "Portfolio Foundation",
+            "subtitle": "Key portfolio dimensions across the dataset period",
+            "type": "chart",
+            "cell": "01-general/02_portfolio_data",
+        },
+        {
+            "num": 3,
+            "title": "Monthly Trends",
+            "subtitle": "Month-over-month portfolio activity",
+            "type": "chart",
+            "cell": "01-general/05_monthly_table",
+        },
+        {
+            "num": 4,
+            "title": "Executive Scorecard",
+            "subtitle": "RAG status across all KPI dimensions",
+            "type": "chart",
+            "cell": "22-executive/02_scorecard_dashboard",
+        },
+        {
+            "num": 5,
+            "title": "RED KPI Spotlight",
+            "subtitle": "KPIs requiring immediate attention",
+            "type": "chart",
+            "cell": "22-executive/01_scorecard_data",
+            "filter": "red_only",
+        },
+        {
+            "num": 6,
+            "title": "Strategic Priorities",
+            "subtitle": "Recommended focus areas ranked by impact",
+            "type": "chart",
+            "cell": "22-executive/03_strategic_priorities",
+        },
+        {
+            "num": 7,
+            "title": "Revenue Opportunity Waterfall",
+            "subtitle": "Estimated annual impact across all analysis areas",
+            "type": "chart",
+            "cell": "22-executive/04_opportunity_waterfall",
+        },
+        {
+            "num": 8,
+            "title": "Competition Teaser",
+            "subtitle": "Competitor presence in your member base",
+            "type": "chart",
+            "cell": "06-direct-competition/21_segment_summary",
+        },
+        {
+            "num": 9,
+            "title": "Attrition Teaser",
+            "subtitle": "Members showing declining engagement",
+            "type": "chart",
+            "cell": "13-attrition/02_attrition_kpi",
+        },
+        {
+            "num": 10,
+            "title": "Relationship Teaser",
+            "subtitle": "Product depth and cross-sell opportunity",
+            "type": "chart",
+            "cell": "18-relationship/02_relationship_kpi",
+        },
+        {
+            "num": 11,
+            "title": "Campaign ROI Teaser",
+            "subtitle": "ARS mailer program effectiveness",
+            "type": "chart",
+            "cell": "09-ars-campaign/42_campaign_summary_slide",
+        },
+        {
+            "num": 12,
+            "title": "Segment Migration",
+            "subtitle": "Engagement tier movement over time",
+            "type": "chart",
+            "cell": "19-segment-evolution/02_segment_kpi",
+        },
+        {
+            "num": 13,
+            "title": "Action Roadmap",
+            "subtitle": "Phased implementation plan",
+            "type": "chart",
+            "cell": "22-executive/05_action_roadmap",
+        },
+        {
+            "num": 14,
+            "title": "Next Steps",
+            "subtitle": "Immediate actions and follow-up timeline",
+            "type": "text",
+            "cell": None,
+            "content_key": "next_steps",
+        },
+        {
+            "num": 15,
+            "title": "Data Sources & Methodology",
+            "subtitle": "Dataset coverage and analytical approach",
+            "type": "text",
+            "cell": None,
+            "content_key": "data_sources",
+        },
+    ],
+    "exec_summary_template": (
+        "Across {n_dimensions} KPI dimensions, {n_red} RED / {n_amber} AMBER. "
+        "Combined annual opportunity: {total_opportunity}. "
+        "Largest lever: {largest_lever}."
+    ),
+    "kpi_keys": [
+        "scorecard_green_count",
+        "scorecard_amber_count",
+        "scorecard_red_count",
+        "total_opportunity",
+        "pct_accounts_at_risk",
+        "largest_opportunity_area",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Storyline 2: Competitive Threat & Wallet Share (CORE)
+# ---------------------------------------------------------------------------
+STORYLINES["competitive_threat"] = {
+    "id": 2,
+    "title": "Competitive Threat & Wallet Share",
+    "tagline": "Who Else Has Your Members' Wallet?",
+    "type": "CORE",
+    "audience": "CEO, VP Marketing, VP Ops",
+    "duration_min": 20,
+    "slides": [
+        {
+            "num": 1,
+            "title": "Competitive Threat & Wallet Share",
+            "subtitle": "Who Else Has Your Members' Wallet?",
+            "type": "title",
+            "cell": None,
+        },
+        {
+            "num": 2,
+            "title": "Executive Summary",
+            "subtitle": "Key competitive findings",
+            "type": "exec_summary",
+            "cell": None,
+        },
+        {
+            "num": 3,
+            "title": "Detection Methodology",
+            "subtitle": "How we identify competitor transactions",
+            "type": "chart",
+            "cell": "06-direct-competition/01_competitor_config",
+        },
+        {
+            "num": 4,
+            "title": "Landscape Overview",
+            "subtitle": "Competitor presence across the portfolio",
+            "type": "chart",
+            "cell": "06-direct-competition/02_competitor_detection",
+        },
+        {
+            "num": 5,
+            "title": "Wallet Share Segmentation",
+            "subtitle": "Members categorized by competitor spend share",
+            "type": "chart",
+            "cell": "06-direct-competition/20_spend_segmentation",
+        },
+        {
+            "num": 6,
+            "title": "Segment Summary Table",
+            "subtitle": "Account counts and spend by competitor tier",
+            "type": "chart",
+            "cell": "06-direct-competition/21_segment_summary",
+        },
+        {
+            "num": 7,
+            "title": "Top Competitors",
+            "subtitle": "Most frequently detected competing institutions",
+            "type": "chart",
+            "cell": "06-direct-competition/22_segment_top_competitors",
+        },
+        {
+            "num": 8,
+            "title": "Category Breakdown",
+            "subtitle": "Competitor activity by financial product category",
+            "type": "chart",
+            "cell": "06-direct-competition/23_segment_by_category",
+        },
+        {
+            "num": 9,
+            "title": "Risk Heatmap",
+            "subtitle": "Competitor threat intensity by segment",
+            "type": "chart",
+            "cell": "06-direct-competition/24_segment_heatmap",
+        },
+        {
+            "num": 10,
+            "title": "At-Risk Accounts",
+            "subtitle": "Accounts with highest competitor wallet share",
+            "type": "chart",
+            "cell": "06-direct-competition/25_at_risk_accounts",
+        },
+        {
+            "num": 11,
+            "title": "Spend Scatter: CU vs Competitor",
+            "subtitle": "Your share vs competitor share per account",
+            "type": "chart",
+            "cell": "06-direct-competition/26_spend_scatter",
+        },
+        {
+            "num": 12,
+            "title": "Recency Analysis",
+            "subtitle": "When members last transacted with competitors",
+            "type": "chart",
+            "cell": "06-direct-competition/27_recency_analysis",
+        },
+        {
+            "num": 13,
+            "title": "Wallet Share Distribution",
+            "subtitle": "Distribution of competitor wallet share percentage",
+            "type": "chart",
+            "cell": "06-direct-competition/29_wallet_share",
+        },
+        {
+            "num": 14,
+            "title": "FinServ Leakage KPIs",
+            "subtitle": "Financial services transaction leakage metrics",
+            "type": "chart",
+            "cell": "07-financial-services/06_kpi_dashboard",
+        },
+        {
+            "num": 15,
+            "title": "FinServ Opportunity",
+            "subtitle": "Revenue opportunity from external FinServ recapture",
+            "type": "chart",
+            "cell": "07-financial-services/18_opportunity_waterfall",
+        },
+        {
+            "num": 16,
+            "title": "Top External Merchants",
+            "subtitle": "Most popular external financial service providers",
+            "type": "chart",
+            "cell": "07-financial-services/09_top_merchants",
+        },
+        {
+            "num": 17,
+            "title": "FinServ Recency",
+            "subtitle": "Recency of external financial transactions",
+            "type": "chart",
+            "cell": "07-financial-services/10_recency_heatmap",
+        },
+        {
+            "num": 18,
+            "title": "Multi-Product External",
+            "subtitle": "Members using multiple external financial providers",
+            "type": "chart",
+            "cell": "07-financial-services/12_multi_product",
+        },
+        {
+            "num": 19,
+            "title": "Action Lists",
+            "subtitle": "Exportable target lists for win-back campaigns",
+            "type": "chart",
+            "cell": "06-direct-competition/41_export_lists",
+        },
+        {
+            "num": 20,
+            "title": "Recommendations",
+            "subtitle": "Strategic recommendations for competitive response",
+            "type": "text",
+            "cell": None,
+            "content_key": "competitive_recommendations",
+        },
+    ],
+    "exec_summary_template": (
+        "{pct_with_competitor}% of members transact at competing FIs, "
+        "{competitor_heavy_count} accounts in 'Competitor-Heavy' tier "
+        "(>50% wallet share elsewhere)."
+    ),
+    "kpi_keys": [
+        "competitors_detected",
+        "pct_with_competitor_activity",
+        "competitor_heavy_count",
+        "pct_paying_external_finserv",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Storyline 3: Member Retention & Attrition Risk (CORE)
+# ---------------------------------------------------------------------------
+STORYLINES["retention_attrition"] = {
+    "id": 3,
+    "title": "Member Retention & Attrition Risk",
+    "tagline": "The Silent Departure",
+    "type": "CORE",
+    "audience": "VP Member Experience, CEO, Retention Team",
+    "duration_min": 15,
+    "slides": [
+        {
+            "num": 1,
+            "title": "Member Retention & Attrition Risk",
+            "subtitle": "The Silent Departure",
+            "type": "title",
+            "cell": None,
+        },
+        {
+            "num": 2,
+            "title": "Executive Summary",
+            "subtitle": "Key retention findings",
+            "type": "exec_summary",
+            "cell": None,
+        },
+        {
+            "num": 3,
+            "title": "Attrition KPIs",
+            "subtitle": "Risk at a glance",
+            "type": "chart",
+            "cell": "13-attrition/02_attrition_kpi",
+        },
+        {
+            "num": 4,
+            "title": "Risk Tier Distribution",
+            "subtitle": "Portfolio breakdown by risk category",
+            "type": "chart",
+            "cell": "13-attrition/03_risk_distribution",
+        },
+        {
+            "num": 5,
+            "title": "Velocity Scatter",
+            "subtitle": "Spend velocity ratio identifies declining members",
+            "type": "chart",
+            "cell": "13-attrition/04_velocity_scatter",
+        },
+        {
+            "num": 6,
+            "title": "Monthly Risk Progression",
+            "subtitle": "How risk tiers evolve over time",
+            "type": "chart",
+            "cell": "13-attrition/05_monthly_progression",
+        },
+        {
+            "num": 7,
+            "title": "Risk by Demographics",
+            "subtitle": "Attrition patterns across age and tenure groups",
+            "type": "chart",
+            "cell": "13-attrition/06_risk_by_demographics",
+        },
+        {
+            "num": 8,
+            "title": "Risk by Product",
+            "subtitle": "Which products see the most attrition",
+            "type": "chart",
+            "cell": "13-attrition/07_risk_by_product",
+        },
+        {
+            "num": 9,
+            "title": "Risk by Competitor Activity",
+            "subtitle": "Correlation between competitor presence and attrition",
+            "type": "chart",
+            "cell": "13-attrition/08_risk_by_competitor",
+        },
+        {
+            "num": 10,
+            "title": "Early Warning Signals",
+            "subtitle": "Behavioral patterns that predict attrition",
+            "type": "chart",
+            "cell": "13-attrition/09_early_warning",
+        },
+        {
+            "num": 11,
+            "title": "Dormancy Progression",
+            "subtitle": "Path from active to dormant accounts",
+            "type": "chart",
+            "cell": "13-attrition/10_dormancy_progression",
+        },
+        {
+            "num": 12,
+            "title": "Retention KPIs",
+            "subtitle": "Account health classification summary",
+            "type": "chart",
+            "cell": "20-retention/02_retention_kpi",
+        },
+        {
+            "num": 13,
+            "title": "Churn by Segment",
+            "subtitle": "Retention rates across engagement tiers",
+            "type": "chart",
+            "cell": "20-retention/03_churn_by_segment",
+        },
+        {
+            "num": 14,
+            "title": "Attrition Cost",
+            "subtitle": "Financial impact of member departure",
+            "type": "chart",
+            "cell": "20-retention/04_attrition_cost",
+        },
+        {
+            "num": 15,
+            "title": "Dormancy Funnel",
+            "subtitle": "Active to dormant conversion stages",
+            "type": "chart",
+            "cell": "20-retention/05_dormancy_funnel",
+        },
+        {
+            "num": 16,
+            "title": "Early Warning Map",
+            "subtitle": "Visual map of early warning indicators",
+            "type": "chart",
+            "cell": "20-retention/06_early_warning",
+        },
+        {
+            "num": 17,
+            "title": "Engagement Migration KPIs",
+            "subtitle": "Monthly engagement tier changes",
+            "type": "chart",
+            "cell": "21-engagement-migration/02_migration_kpi",
+        },
+        {
+            "num": 18,
+            "title": "Migration Matrix",
+            "subtitle": "From-to movement between engagement tiers",
+            "type": "chart",
+            "cell": "21-engagement-migration/03_migration_matrix",
+        },
+        {
+            "num": 19,
+            "title": "Net Flow",
+            "subtitle": "Monthly net migration between tiers",
+            "type": "chart",
+            "cell": "21-engagement-migration/04_net_flow",
+        },
+        {
+            "num": 20,
+            "title": "Migration by Segment",
+            "subtitle": "Which segments gain and lose members",
+            "type": "chart",
+            "cell": "21-engagement-migration/05_migration_by_segment",
+        },
+        {
+            "num": 21,
+            "title": "At-Risk Export Lists",
+            "subtitle": "Downloadable lists for targeted outreach",
+            "type": "chart",
+            "cell": "13-attrition/11_at_risk_export",
+        },
+        {
+            "num": 22,
+            "title": "Action Plan",
+            "subtitle": "Recommended retention interventions",
+            "type": "chart",
+            "cell": "13-attrition/12_action_summary",
+        },
+    ],
+    "exec_summary_template": (
+        "{pct_at_risk}% at risk ({n_at_risk} members), "
+        "{spend_at_risk} annual spend exposed. "
+        "Velocity detection catches them 30-60 days before dormancy."
+    ),
+    "kpi_keys": [
+        "pct_at_risk",
+        "spend_at_risk",
+        "closed_account_rate",
+        "net_migration_direction",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Storyline 4: Revenue Optimization (CORE)
+# ---------------------------------------------------------------------------
+STORYLINES["revenue_optimization"] = {
+    "id": 4,
+    "title": "Revenue Optimization",
+    "tagline": "Finding Revenue in the Card Portfolio",
+    "type": "CORE",
+    "audience": "CFO, VP Card Services, VP Payments",
+    "duration_min": 15,
+    "slides": [
+        {
+            "num": 1,
+            "title": "Revenue Optimization",
+            "subtitle": "Finding Revenue in the Card Portfolio",
+            "type": "title",
+            "cell": None,
+        },
+        {
+            "num": 2,
+            "title": "Executive Summary",
+            "subtitle": "Key revenue findings",
+            "type": "exec_summary",
+            "cell": None,
+        },
+        {
+            "num": 3,
+            "title": "Interchange KPIs",
+            "subtitle": "PIN vs signature interchange overview",
+            "type": "chart",
+            "cell": "15-interchange/02_interchange_kpi",
+        },
+        {
+            "num": 4,
+            "title": "PIN vs SIG Trend",
+            "subtitle": "Monthly interchange method trends",
+            "type": "chart",
+            "cell": "15-interchange/03_pin_sig_trend",
+        },
+        {
+            "num": 5,
+            "title": "SIG Ratio Analysis",
+            "subtitle": "Signature transaction share over time",
+            "type": "chart",
+            "cell": "15-interchange/04_pin_sig_ratio",
+        },
+        {
+            "num": 6,
+            "title": "Revenue Waterfall",
+            "subtitle": "Interchange revenue opportunity breakdown",
+            "type": "chart",
+            "cell": "15-interchange/05_revenue_waterfall",
+        },
+        {
+            "num": 7,
+            "title": "PIN-Heavy Accounts",
+            "subtitle": "Accounts with highest PIN-to-SIG conversion opportunity",
+            "type": "chart",
+            "cell": "15-interchange/06_pin_heavy_accounts",
+        },
+        {
+            "num": 8,
+            "title": "IC by Demographics",
+            "subtitle": "Interchange patterns across age and tenure",
+            "type": "chart",
+            "cell": "15-interchange/07_interchange_by_demographics",
+        },
+        {
+            "num": 9,
+            "title": "IC by Merchant",
+            "subtitle": "Interchange revenue by top merchant categories",
+            "type": "chart",
+            "cell": "15-interchange/08_interchange_by_merchant",
+        },
+        {
+            "num": 10,
+            "title": "IC by Product",
+            "subtitle": "Interchange performance by card product",
+            "type": "chart",
+            "cell": "15-interchange/09_interchange_by_product",
+        },
+        {
+            "num": 11,
+            "title": "Reg E KPIs",
+            "subtitle": "Overdraft opt-in program overview",
+            "type": "chart",
+            "cell": "16-rege-overdraft/02_rege_kpi",
+        },
+        {
+            "num": 12,
+            "title": "Opt-In Trend",
+            "subtitle": "Reg E opt-in rate over time",
+            "type": "chart",
+            "cell": "16-rege-overdraft/03_optin_trend",
+        },
+        {
+            "num": 13,
+            "title": "Opt-In Migration",
+            "subtitle": "Members changing opt-in status",
+            "type": "chart",
+            "cell": "16-rege-overdraft/04_optin_migration",
+        },
+        {
+            "num": 14,
+            "title": "OD Limit Distribution",
+            "subtitle": "Overdraft limit tiers across opted-in accounts",
+            "type": "chart",
+            "cell": "16-rege-overdraft/05_od_limit_distribution",
+        },
+        {
+            "num": 15,
+            "title": "OD Limit Trend",
+            "subtitle": "Average overdraft limit over time",
+            "type": "chart",
+            "cell": "16-rege-overdraft/06_od_limit_trend",
+        },
+        {
+            "num": 16,
+            "title": "Reg E by Demographics",
+            "subtitle": "Opt-in patterns across demographics",
+            "type": "chart",
+            "cell": "16-rege-overdraft/07_rege_by_demographics",
+        },
+        {
+            "num": 17,
+            "title": "Revenue Exposure",
+            "subtitle": "Potential revenue impact from opt-in changes",
+            "type": "chart",
+            "cell": "16-rege-overdraft/08_rege_revenue_exposure",
+        },
+        {
+            "num": 18,
+            "title": "Reg E vs Balance",
+            "subtitle": "Relationship between balance and opt-in status",
+            "type": "chart",
+            "cell": "16-rege-overdraft/09_rege_vs_balance",
+        },
+        {
+            "num": 19,
+            "title": "Payment Channel Overview",
+            "subtitle": "Transaction distribution across payment channels",
+            "type": "chart",
+            "cell": "11-transaction-type/09_payment_channel_overview",
+        },
+        {
+            "num": 20,
+            "title": "ACH Deep Dive",
+            "subtitle": "ACH transaction patterns and PFI indicators",
+            "type": "chart",
+            "cell": "11-transaction-type/10_ach_deep_dive",
+        },
+        {
+            "num": 21,
+            "title": "Channel Migration",
+            "subtitle": "Members shifting between payment channels",
+            "type": "chart",
+            "cell": "11-transaction-type/12_channel_migration",
+        },
+        {
+            "num": 22,
+            "title": "Action Plan",
+            "subtitle": "Revenue optimization recommendations",
+            "type": "chart",
+            "cell": "11-transaction-type/15_ach_chk_action_summary",
+        },
+    ],
+    "exec_summary_template": (
+        "Annual IC est. {annual_ic}, SIG ratio {sig_ratio}%. "
+        "10% PIN shift = +{pin_shift_gain}/yr. "
+        "Reg E opt-in {optin_rate}%."
+    ),
+    "kpi_keys": [
+        "annual_ic_revenue",
+        "sig_ratio_pct",
+        "pin_shift_revenue_gain",
+        "rege_optin_rate",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Storyline 5: ARS Campaign Performance (SITUATIONAL)
+# ---------------------------------------------------------------------------
+STORYLINES["ars_campaign"] = {
+    "id": 5,
+    "title": "ARS Campaign Performance",
+    "tagline": "Proving the Mailer Works",
+    "type": "SITUATIONAL",
+    "audience": "VP Marketing, CEO, Board",
+    "duration_min": 15,
+    "slides": [
+        {
+            "num": 1,
+            "title": "ARS Campaign Performance",
+            "subtitle": "Proving the Mailer Works",
+            "type": "title",
+            "cell": None,
+        },
+        {
+            "num": 2,
+            "title": "Executive Summary",
+            "subtitle": "Campaign impact at a glance",
+            "type": "chart",
+            "cell": "09-ars-campaign/42_campaign_summary_slide",
+        },
+        {
+            "num": 3,
+            "title": "Program Reach KPIs",
+            "subtitle": "Mail volume, response rates, and penetration",
+            "type": "chart",
+            "cell": "09-ars-campaign/02_campaign_kpi",
+        },
+        {
+            "num": 4,
+            "title": "Response Grouping",
+            "subtitle": "Classification of responder vs non-responder",
+            "type": "chart",
+            "cell": "09-ars-campaign/03_campaign_response_grouping",
+        },
+        {
+            "num": 5,
+            "title": "Penetration",
+            "subtitle": "Mailer reach across the portfolio",
+            "type": "chart",
+            "cell": "09-ars-campaign/04_campaign_penetration",
+        },
+        {
+            "num": 6,
+            "title": "Response by Wave",
+            "subtitle": "Response rates across mailing waves",
+            "type": "chart",
+            "cell": "09-ars-campaign/05_response_by_wave",
+        },
+        {
+            "num": 7,
+            "title": "Response Rate Trend",
+            "subtitle": "How response rates evolve over time",
+            "type": "chart",
+            "cell": "09-ars-campaign/06_response_rate_trend",
+        },
+        {
+            "num": 8,
+            "title": "Response Ladder",
+            "subtitle": "Response tier breakdown",
+            "type": "chart",
+            "cell": "09-ars-campaign/07_response_ladder",
+        },
+        {
+            "num": 9,
+            "title": "Revenue Attribution",
+            "subtitle": "Revenue impact attributed to mailer response",
+            "type": "chart",
+            "cell": "09-ars-campaign/08_response_revenue_attribution",
+        },
+        {
+            "num": 10,
+            "title": "DID Methodology Explainer",
+            "subtitle": "Difference-in-Differences isolates true causal effect",
+            "type": "chart",
+            "cell": "09-ars-campaign/09_did_explainer",
+        },
+        {
+            "num": 11,
+            "title": "Cohort Lift KPIs",
+            "subtitle": "Pre/post spend lift metrics",
+            "type": "chart",
+            "cell": "09-ars-campaign/11_cohort_lift_kpi",
+        },
+        {
+            "num": 12,
+            "title": "Before/After",
+            "subtitle": "Responder spend trajectory pre vs post mailer",
+            "type": "chart",
+            "cell": "09-ars-campaign/12_cohort_before_after",
+        },
+        {
+            "num": 13,
+            "title": "DID Lift (Key Proof)",
+            "subtitle": "The causal spend lift above counterfactual",
+            "type": "chart",
+            "cell": "09-ars-campaign/13_cohort_did_lift",
+        },
+        {
+            "num": 14,
+            "title": "Spend Persistence",
+            "subtitle": "Does the lift sustain beyond initial activation?",
+            "type": "chart",
+            "cell": "09-ars-campaign/14_cohort_spend_persistence",
+        },
+        {
+            "num": 15,
+            "title": "Cumulative Impact (Hero Chart)",
+            "subtitle": "Total cumulative spend difference since activation",
+            "type": "chart",
+            "cell": "09-ars-campaign/15_cohort_cumulative_spend",
+        },
+        {
+            "num": 16,
+            "title": "Counterfactual",
+            "subtitle": "What would have happened without the mailer?",
+            "type": "chart",
+            "cell": "09-ars-campaign/16_cohort_counterfactual",
+        },
+        {
+            "num": 17,
+            "title": "Swipe KPIs + DID",
+            "subtitle": "Transaction count lift analysis",
+            "type": "chart",
+            "cell": "09-ars-campaign/17_swipe_kpi",
+        },
+        {
+            "num": 18,
+            "title": "Swipe Migration",
+            "subtitle": "Members migrating between swipe frequency tiers",
+            "type": "chart",
+            "cell": "09-ars-campaign/21_swipe_migration_matrix",
+        },
+        {
+            "num": 19,
+            "title": "Segment Spend Comparison",
+            "subtitle": "Responder vs non-responder spend by segment",
+            "type": "chart",
+            "cell": "09-ars-campaign/24_segment_spend_comparison",
+        },
+        {
+            "num": 20,
+            "title": "Segment Trend Lines",
+            "subtitle": "Spend trajectories by segment over time",
+            "type": "chart",
+            "cell": "09-ars-campaign/26_segment_spend_lines",
+        },
+        {
+            "num": 21,
+            "title": "Responder Profile",
+            "subtitle": "Transaction behavior of responders",
+            "type": "chart",
+            "cell": "09-ars-campaign/30_responder_txn_profile",
+        },
+        {
+            "num": 22,
+            "title": "Responder Demographics",
+            "subtitle": "Age and tenure profiles of top responders",
+            "type": "chart",
+            "cell": "09-ars-campaign/34_responder_account_age_chart",
+        },
+        {
+            "num": 23,
+            "title": "Program Effectiveness",
+            "subtitle": "Overall program ROI and efficiency metrics",
+            "type": "chart",
+            "cell": "09-ars-campaign/37_program_effectiveness",
+        },
+        {
+            "num": 24,
+            "title": "Revenue Cascade + What-If",
+            "subtitle": "Per-activation ROI and scenario modeling",
+            "type": "chart",
+            "cell": "09-ars-campaign/39_revenue_cascade",
+        },
+        {
+            "num": 25,
+            "title": "Opportunity Map",
+            "subtitle": "Untapped segments for next campaign wave",
+            "type": "chart",
+            "cell": "09-ars-campaign/40_opportunity_map",
+        },
+    ],
+    "exec_summary_template": (
+        "{penetration_rate}% penetration across {n_waves} waves. "
+        "DID lift: +{did_lift}/mo/acct above counterfactual. "
+        "Best ROI segments: {best_segments}."
+    ),
+    "kpi_keys": [
+        "unique_accounts_mailed",
+        "penetration_rate",
+        "avg_did_spend_lift",
+        "persistence_rate",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Storyline 6: Relationship Depth & Growth (CORE)
+# ---------------------------------------------------------------------------
+STORYLINES["relationship_growth"] = {
+    "id": 6,
+    "title": "Relationship Depth & Growth",
+    "tagline": "From Single-Product to Primary FI",
+    "type": "CORE",
+    "audience": "VP Lending, VP Deposits, CEO, Product Team",
+    "duration_min": 15,
+    "slides": [
+        {
+            "num": 1,
+            "title": "Relationship Depth & Growth",
+            "subtitle": "From Single-Product to Primary FI",
+            "type": "title",
+            "cell": None,
+        },
+        {
+            "num": 2,
+            "title": "Executive Summary",
+            "subtitle": "Key relationship findings",
+            "type": "exec_summary",
+            "cell": None,
+        },
+        {
+            "num": 3,
+            "title": "Relationship KPIs",
+            "subtitle": "Product depth and engagement overview",
+            "type": "chart",
+            "cell": "18-relationship/02_relationship_kpi",
+        },
+        {
+            "num": 4,
+            "title": "Product Count Distribution",
+            "subtitle": "How many products do your members hold?",
+            "type": "chart",
+            "cell": "18-relationship/03_product_count_bar",
+        },
+        {
+            "num": 5,
+            "title": "Single-Product Risk",
+            "subtitle": "Flight risk from single-product members",
+            "type": "chart",
+            "cell": "18-relationship/04_single_product_risk",
+        },
+        {
+            "num": 6,
+            "title": "Cross-Sell Matrix",
+            "subtitle": "Product combination affinity map",
+            "type": "chart",
+            "cell": "18-relationship/05_cross_sell_matrix",
+        },
+        {
+            "num": 7,
+            "title": "Value Curve",
+            "subtitle": "Balance and interchange multiplier by product count",
+            "type": "chart",
+            "cell": "18-relationship/06_relationship_value",
+        },
+        {
+            "num": 8,
+            "title": "Leakage Opportunity",
+            "subtitle": "Revenue leakage from shallow relationships",
+            "type": "chart",
+            "cell": "18-relationship/07_leakage_opportunity",
+        },
+        {
+            "num": 9,
+            "title": "Relationship by Demographics",
+            "subtitle": "Product depth across age and tenure groups",
+            "type": "chart",
+            "cell": "18-relationship/08_relationship_by_demographics",
+        },
+        {
+            "num": 10,
+            "title": "Next-Best-Product",
+            "subtitle": "Recommended cross-sell targets by current holdings",
+            "type": "chart",
+            "cell": "18-relationship/09_next_best_product",
+        },
+        {
+            "num": 11,
+            "title": "Payroll KPIs",
+            "subtitle": "Direct deposit detection and PFI indicators",
+            "type": "chart",
+            "cell": "17-payroll/02_payroll_kpi",
+        },
+        {
+            "num": 12,
+            "title": "Payroll Distribution",
+            "subtitle": "Payroll/DD presence across the portfolio",
+            "type": "chart",
+            "cell": "17-payroll/03_payroll_distribution",
+        },
+        {
+            "num": 13,
+            "title": "Payroll Value",
+            "subtitle": "Members with payroll hold higher balances",
+            "type": "chart",
+            "cell": "17-payroll/04_payroll_value",
+        },
+        {
+            "num": 14,
+            "title": "Payroll by Demographics",
+            "subtitle": "Direct deposit patterns across demographics",
+            "type": "chart",
+            "cell": "17-payroll/05_payroll_by_demographics",
+        },
+        {
+            "num": 15,
+            "title": "Payroll Processors",
+            "subtitle": "Top payroll and direct deposit sources",
+            "type": "chart",
+            "cell": "17-payroll/06_payroll_processors",
+        },
+        {
+            "num": 16,
+            "title": "Payroll & Retention",
+            "subtitle": "Payroll members show higher retention",
+            "type": "chart",
+            "cell": "17-payroll/07_payroll_retention",
+        },
+        {
+            "num": 17,
+            "title": "PFI Composite Score",
+            "subtitle": "Multi-factor primary FI likelihood scoring",
+            "type": "chart",
+            "cell": "17-payroll/08_pfi_composite_score",
+        },
+        {
+            "num": 18,
+            "title": "PFI vs Competitor",
+            "subtitle": "Your PFI status vs competitor positioning",
+            "type": "chart",
+            "cell": "17-payroll/09_pfi_vs_competitor",
+        },
+        {
+            "num": 19,
+            "title": "Balance KPIs",
+            "subtitle": "Deposit balance overview",
+            "type": "chart",
+            "cell": "14-balance/02_balance_kpi",
+        },
+        {
+            "num": 20,
+            "title": "Balance vs Activity",
+            "subtitle": "Correlation between balance and card activity",
+            "type": "chart",
+            "cell": "14-balance/05_balance_vs_activity",
+        },
+        {
+            "num": 21,
+            "title": "Deposit Flight Risk",
+            "subtitle": "Balances at risk from declining engagement",
+            "type": "chart",
+            "cell": "14-balance/06_deposit_flight_risk",
+        },
+        {
+            "num": 22,
+            "title": "Action Plan",
+            "subtitle": "Cross-sell and PFI growth recommendations",
+            "type": "chart",
+            "cell": "18-relationship/10_action_summary",
+        },
+    ],
+    "exec_summary_template": (
+        "Avg {avg_products} products/member, {pct_single_product}% single-product. "
+        "3+ members = {balance_multiplier}x balance. "
+        "{pct_with_payroll}% have detected payroll."
+    ),
+    "kpi_keys": [
+        "avg_products_per_member",
+        "pct_single_product",
+        "balance_multiplier_3plus",
+        "pct_with_payroll",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Storyline 7: Portfolio Intelligence & Spending (SITUATIONAL)
+# ---------------------------------------------------------------------------
+STORYLINES["portfolio_intelligence"] = {
+    "id": 7,
+    "title": "Portfolio Intelligence & Spending",
+    "tagline": "Know Your Members",
+    "type": "SITUATIONAL",
+    "audience": "VP Marketing, VP Ops, Branch Managers",
+    "duration_min": 10,
+    "slides": [
+        {
+            "num": 1,
+            "title": "Portfolio Intelligence & Spending",
+            "subtitle": "Know Your Members",
+            "type": "title",
+            "cell": None,
+        },
+        {
+            "num": 2,
+            "title": "Executive Summary",
+            "subtitle": "Key portfolio intelligence findings",
+            "type": "exec_summary",
+            "cell": None,
+        },
+        {
+            "num": 3,
+            "title": "Portfolio KPIs",
+            "subtitle": "Portfolio dimensions and activity metrics",
+            "type": "chart",
+            "cell": "01-general/02_portfolio_data",
+        },
+        {
+            "num": 4,
+            "title": "Monthly Trends",
+            "subtitle": "Month-over-month activity patterns",
+            "type": "chart",
+            "cell": "01-general/05_monthly_table",
+        },
+        {
+            "num": 5,
+            "title": "Demographics",
+            "subtitle": "Member age and demographic distribution",
+            "type": "chart",
+            "cell": "01-general/11_demographic_data",
+        },
+        {
+            "num": 6,
+            "title": "Age-Time Patterns",
+            "subtitle": "Spending behavior across age and time",
+            "type": "chart",
+            "cell": "01-general/13_age_time_patterns",
+        },
+        {
+            "num": 7,
+            "title": "Age-Spending Profile",
+            "subtitle": "Spend volume and ticket size by generation",
+            "type": "chart",
+            "cell": "01-general/14_age_spending_profile",
+        },
+        {
+            "num": 8,
+            "title": "Age Bracket Comparison",
+            "subtitle": "Generational spending differences",
+            "type": "chart",
+            "cell": "01-general/15_age_bracket_comparison",
+        },
+        {
+            "num": 9,
+            "title": "Account Lifecycle",
+            "subtitle": "Activity patterns by account age",
+            "type": "chart",
+            "cell": "01-general/23_account_age_data",
+        },
+        {
+            "num": 10,
+            "title": "Time to First Transaction",
+            "subtitle": "How quickly new accounts activate",
+            "type": "chart",
+            "cell": "01-general/25_time_to_first_txn",
+        },
+        {
+            "num": 11,
+            "title": "Spend by Account Age",
+            "subtitle": "Spending maturity curve",
+            "type": "chart",
+            "cell": "01-general/26_spend_by_account_age",
+        },
+        {
+            "num": 12,
+            "title": "New Account Profile",
+            "subtitle": "Characteristics of recently opened accounts",
+            "type": "chart",
+            "cell": "01-general/27_new_account_profile",
+        },
+        {
+            "num": 13,
+            "title": "Lifecycle Summary",
+            "subtitle": "Key lifecycle stage metrics",
+            "type": "chart",
+            "cell": "01-general/28_lifecycle_summary",
+        },
+        {
+            "num": 14,
+            "title": "Top Categories (MCC)",
+            "subtitle": "Where your members spend the most",
+            "type": "chart",
+            "cell": "03-mcc-code/03_mcc_top20_bar",
+        },
+        {
+            "num": 15,
+            "title": "Category Concentration",
+            "subtitle": "Portfolio spend concentration across categories",
+            "type": "chart",
+            "cell": "03-mcc-code/06_mcc_concentration",
+        },
+        {
+            "num": 16,
+            "title": "Category Trends",
+            "subtitle": "Category spend evolution over time",
+            "type": "chart",
+            "cell": "03-mcc-code/07_mcc_trend",
+        },
+        {
+            "num": 17,
+            "title": "Categories by Age & Tenure",
+            "subtitle": "Spending categories differ by generation",
+            "type": "chart",
+            "cell": "03-mcc-code/08_mcc_by_age_band",
+        },
+        {
+            "num": 18,
+            "title": "Seasonal Patterns",
+            "subtitle": "Monthly and seasonal spending cycles",
+            "type": "chart",
+            "cell": "03-mcc-code/12_mcc_seasonal",
+        },
+        {
+            "num": 19,
+            "title": "Spending Diversity",
+            "subtitle": "How many categories do members use?",
+            "type": "chart",
+            "cell": "03-mcc-code/13_mcc_diversity",
+        },
+        {
+            "num": 20,
+            "title": "Segment Evolution",
+            "subtitle": "Engagement tier changes over time",
+            "type": "chart",
+            "cell": "19-segment-evolution/02_segment_kpi",
+        },
+        {
+            "num": 21,
+            "title": "Upgraders vs Degraders",
+            "subtitle": "Who improved and who declined?",
+            "type": "chart",
+            "cell": "19-segment-evolution/05_upgraders_vs_degraders",
+        },
+        {
+            "num": 22,
+            "title": "Action Plan",
+            "subtitle": "Marketing intelligence recommendations",
+            "type": "chart",
+            "cell": "03-mcc-code/15_mcc_action_summary",
+        },
+    ],
+    "exec_summary_template": (
+        "{total_accounts} accounts, {total_merchants} merchants, "
+        "{total_categories} categories. "
+        "{pct_upgraded}% upgraded engagement segments. "
+        "New accounts activate within {time_to_first_txn} months."
+    ),
+    "kpi_keys": [
+        "total_spend",
+        "top_3_categories",
+        "pct_upgraded_vs_degraded",
+        "time_to_first_txn",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Presentation order (full client review)
+# ---------------------------------------------------------------------------
+PRESENTATION_ORDER = [
+    "executive_health_check",
+    "competitive_threat",
+    "retention_attrition",
+    "revenue_optimization",
+    "relationship_growth",
+    "ars_campaign",
+    "portfolio_intelligence",
+]
+
+# ---------------------------------------------------------------------------
+# Classification helper
+# ---------------------------------------------------------------------------
+CORE_STORYLINES = [k for k, v in STORYLINES.items() if v["type"] == "CORE"]
+SITUATIONAL_STORYLINES = [k for k, v in STORYLINES.items() if v["type"] == "SITUATIONAL"]
+
+
+def get_all_cell_refs():
+    """Return set of all cell references across all storylines."""
+    cells = set()
+    for storyline in STORYLINES.values():
+        for slide in storyline["slides"]:
+            if slide.get("cell"):
+                cells.add(slide["cell"])
+    return cells
+
+
+def get_storyline_by_id(storyline_id):
+    """Look up storyline config by numeric ID (1-7)."""
+    for key, config in STORYLINES.items():
+        if config["id"] == storyline_id:
+            return key, config
+    return None, None


### PR DESCRIPTION
## Summary
- Adds 7 narrative storyline decks (5 CORE, 2 SITUATIONAL) with 148 total slides across all decks
- PPTX engine re-executes chart cells with `plt.show()` intercepted to capture PNGs -- zero modifications to existing 126 chart cells
- Branded slide templates: navy title bars, KPI cards, exec summary slides, chart slides with auto-fit, and footers with dataset label + page numbers

## Storylines
| # | Deck | Type | Slides |
|---|------|------|--------|
| 1 | Executive Health Check | CORE | 15 |
| 2 | Competitive Threat & Wallet Share | CORE | 20 |
| 3 | Member Retention & Attrition Risk | CORE | 22 |
| 4 | Revenue Optimization | CORE | 22 |
| 5 | ARS Campaign Performance | SITUATIONAL | 25 |
| 6 | Relationship Depth & Growth | CORE | 22 |
| 7 | Portfolio Intelligence & Spending | SITUATIONAL | 22 |

## Files
- `dashboard/storyline_config.py` -- slide order, titles, cell refs, KPI keys, exec summary templates
- `dashboard/pptx_engine.py` -- python-pptx export engine with re-execution renderer
- `dashboard/__init__.py` -- package exports
- `22-executive/10_pptx_figure_registry` -- notebook setup cell
- `22-executive/11_pptx_export` -- notebook export cell

## Test plan
- [x] All 126 cell references resolve to existing files
- [x] All 7 PPTX files generate valid presentations (tested with python-pptx)
- [x] Slide counts match spec (15/20/22/22/25/22/22)
- [x] `render_cell_to_png` captures charts via plt.show() interception
- [ ] End-to-end test with live notebook data

🤖 Generated with [Claude Code](https://claude.com/claude-code)